### PR TITLE
Nix support (using a flake)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ I think there should be _some_ flexibility as to the exact version of libocct re
 For nix there is a flake provided, you can get a shell with Waterfall using:
 
 ```
-> nix develop github:ArtemChandragupta/opencascade-hs
+> nix develop github:joe-warren/opencascade-hs
 ```
 
 ### MacOS

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ As this library depends on OpenCASCADE, I've been developing on Debian with the 
 
 I think there should be _some_ flexibility as to the exact version of libocct required, and which occt packages are necessary.
 
+### Nix
+
+For nix there is a flake provided, you can get a shell with Waterfall using:
+
+```
+> nix develop github:ArtemChandragupta/opencascade-hs
+```
+
 ### MacOS
 
 On MacOS, you should be able to install [OpenCASCADE](https://formulae.brew.sh/formula/opencascade) via [homebrew](https://brew.sh/):

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,58 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1727826117,
+        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1729880355,
+        "narHash": "sha256-RP+OQ6koQQLX5nw0NmcDrzvGL8HDLnyXt/jHhL1jwjM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18536bf04cd71abd345f9579158841376fdd0c5a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1727825735,
+        "narHash": "sha256-0xHYkMkeLVQAMa7gvkddbPqpxph+hDzdu1XdGPJR+Os=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,54 @@
+{
+
+inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+inputs.flake-parts.url = "github:hercules-ci/flake-parts";
+
+outputs = inputs: inputs.flake-parts.lib.mkFlake { inputs = inputs; } {
+
+  systems = [ "x86_64-linux" ];
+  imports = [ inputs.flake-parts.flakeModules.easyOverlay ];
+
+  perSystem = {pkgs, ...}: let
+    system = "x86_64-linux";
+    compilerVersion = "ghc966";
+    config = {
+      packageOverrides = pkgs: rec {
+        haskell = pkgs.haskell // {
+	  packages = pkgs.haskell.packages // {
+	    ghc966 = pkgs.haskell.packages."${compilerVersion}".override {
+	      overrides = self: super: {
+	        opencascade-hs = haskell.lib.compose.overrideCabal (old: { configureFlags = old.configureFlags or [] ++ ["--extra-include-dirs=${pkgs.opencascade-occt}/include/opencascade"]; }) (pkgs.haskell.lib.addExtraLibrary super.opencascade-hs pkgs.opencascade-occt); 
+	      };
+	    };
+          };
+        };
+      };
+      allowBroken = true;
+    };
+    pkgs = import inputs.nixpkgs { inherit system config; };
+    compiler = pkgs.haskell.packages."${compilerVersion}";
+
+    waterfall-pkg = compiler.developPackage {
+      root = ./waterfall-cad-examples; # Want to set ./waterfall-cad, but it has no executable and for that reason don't work
+    };
+
+    waterfall-dev-shell = compiler.shellFor {
+      # Which haskell packages to prepare a dev env for
+      packages = _: [waterfall-pkg];
+      # Extra software to provide in the dev shell
+      nativeBuildInputs = [
+        pkgs.cabal-install
+        pkgs.haskell-language-server
+	pkgs.haskellPackages.linear
+      ];
+    };
+
+  in {
+    packages.default  = waterfall-pkg;        # Entry point for `nix build`
+    devShells.default = waterfall-dev-shell;  # Entry point for `nix develop`
+
+    overlayAttrs.packages.haskellPackages.waterfall-cad = waterfall-pkg; # Overriding package from nixpkgs in configuration
+  };
+};
+
+}


### PR DESCRIPTION
Hello. This pull request consist of a flake used to create a development shell for Waterfall-cad on NixOS. This works on my machine and machine of [Kovalev Dmitry](https://github.com/KovalevDima)

Also there is a mention of Nix installation method in Readme.md.