### PR TITLE
Wasm build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+FROM debian:testing-slim
+## This is a dockerized build of my (currently failing) attempt to get opencascade-hs to build to wasm
+# docker isn't a tremendously sensible way to automate this, but I barely know nix
+# the purpose of this is more to document "what I'm doing" so I can share errors in a repeatable way
+# as opposed to being the basis of a reusable build environment
+
+# use bash as the shell, we're going to be using `source` a lot
+SHELL ["/bin/bash", "-c"]
+
+# install system dependencies
+RUN apt-get update
+RUN apt-get -y install git python3 xz-utils cmake curl jq zip zstd
+
+# setup ssh key (not used)
+RUN mkdir ~/.ssh
+RUN ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
+
+# clone source dependencies
+RUN git clone --depth 1 https://github.com/Open-Cascade-SAS/OCCT.git
+
+RUN git clone --depth 1 https://github.com/freetype/freetype.git
+
+RUN git clone --depth 1 https://github.com/Tencent/rapidjson.git
+
+RUN git clone --depth 1 https://github.com/emscripten-core/emsdk.git
+
+# install and activate emsdk
+WORKDIR /emsdk
+RUN ./emsdk install latest
+RUN ./emsdk activate latest
+RUN source ./emsdk_env.sh
+
+# overwrite opencascade build scripts
+WORKDIR /
+COPY scripts/occt/wasm_build.sh OCCT/adm/scripts/wasm_build.sh
+COPY scripts/occt/wasm_custom.sh OCCT/adm/scripts/wasm_custom.sh
+
+# run opencascade wasm build
+RUN chmod +x ./OCCT/adm/scripts/wasm_build.sh
+RUN ./OCCT/adm/scripts/wasm_build.sh
+
+# install ghc-wasm
+RUN curl https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta/-/raw/master/bootstrap.sh | sh
+
+# copy in opencascade-hs source 
+RUN mkdir opencascade-hs
+COPY . /opencascade-hs
+
+# attempt to build opencascade-hs
+WORKDIR /opencascade-hs
+RUN source ~/.ghc-wasm/env && wasm32-wasi-cabal build all

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,13 +22,8 @@ RUN git clone --depth 1 https://github.com/freetype/freetype.git
 
 RUN git clone --depth 1 https://github.com/Tencent/rapidjson.git
 
-RUN git clone --depth 1 https://github.com/emscripten-core/emsdk.git
-
-# install and activate emsdk
-WORKDIR /emsdk
-RUN ./emsdk install latest
-RUN ./emsdk activate latest
-RUN source ./emsdk_env.sh
+# install ghc-wasm
+RUN curl https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta/-/raw/master/bootstrap.sh | sh
 
 # overwrite opencascade build scripts
 WORKDIR /
@@ -38,9 +33,6 @@ COPY scripts/occt/wasm_custom.sh OCCT/adm/scripts/wasm_custom.sh
 # run opencascade wasm build
 RUN chmod +x ./OCCT/adm/scripts/wasm_build.sh
 RUN ./OCCT/adm/scripts/wasm_build.sh
-
-# install ghc-wasm
-RUN curl https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta/-/raw/master/bootstrap.sh | sh
 
 # copy in opencascade-hs source 
 RUN mkdir opencascade-hs

--- a/cabal.project
+++ b/cabal.project
@@ -7,3 +7,7 @@ packages:
 package *
   ghc-options: -haddock
   documentation: True
+
+allow-newer: all:base
+allow-newer: all:template-haskell
+allow-newer: all:ghc-bignum

--- a/opencascade-hs/opencascade-hs.cabal
+++ b/opencascade-hs/opencascade-hs.cabal
@@ -348,10 +348,9 @@ library
   ld-options: -fwasm-exceptions
   include-dirs:
       cpp
-      /home/joseph/Programming/occt/OCCT/work/wasm/inc/
+      /OCCT/work/wasm/inc/
   extra-lib-dirs:
-      /home/joseph/Programming/occt/emsdk/upstream/lib/
-      /home/joseph/Programming/occt/OCCT/work/wasm/lib/
+      /OCCT/work/wasm/lib/
   cxx-sources:
       cpp/hs_Bnd_Box.cpp
       cpp/hs_Bnd_OBB.cpp

--- a/opencascade-hs/opencascade-hs.cabal
+++ b/opencascade-hs/opencascade-hs.cabal
@@ -344,7 +344,7 @@ library
   hs-source-dirs:
       src
   ghc-options: -Wall -Werror=compat -Werror=identities -Werror=incomplete-record-updates -Werror=incomplete-uni-patterns -Werror=missing-home-modules -Werror=missing-export-lists -Werror=partial-fields -Wwarn=redundant-constraints -optc -Werror-implicit-function-declaration
-  cxx-options: --std=c++17 -Wall -Werror -Wno-deprecated -fexceptions -mllvm -wasm-enable-sjlj -fwasm-exceptions -sDISABLE_EXCEPTION_CATCHING
+  cxx-options: --std=c++17 -Wall -Werror -Wno-deprecated -fexceptions -mllvm -wasm-enable-sjlj -fwasm-exceptions -sDISABLE_EXCEPTION_CATCHING -DNo_Exception
   ld-options: -fwasm-exceptions
   include-dirs:
       cpp

--- a/opencascade-hs/opencascade-hs.cabal
+++ b/opencascade-hs/opencascade-hs.cabal
@@ -343,11 +343,15 @@ library
       Paths_opencascade_hs
   hs-source-dirs:
       src
-  ghc-options: -Wall -Werror=compat -Werror=identities -Werror=incomplete-record-updates -Werror=incomplete-uni-patterns -Werror=missing-home-modules -Werror=missing-export-lists -Werror=partial-fields -Werror=redundant-constraints -optc -Werror-implicit-function-declaration
-  cxx-options: --std=c++17 -Wall -Werror -Wno-deprecated
+  ghc-options: -Wall -Werror=compat -Werror=identities -Werror=incomplete-record-updates -Werror=incomplete-uni-patterns -Werror=missing-home-modules -Werror=missing-export-lists -Werror=partial-fields -Wwarn=redundant-constraints -optc -Werror-implicit-function-declaration
+  cxx-options: --std=c++17 -Wall -Werror -Wno-deprecated -fexceptions -mllvm -wasm-enable-sjlj -fwasm-exceptions -sDISABLE_EXCEPTION_CATCHING
+  ld-options: -fwasm-exceptions
   include-dirs:
       cpp
-      /usr/include/opencascade
+      /home/joseph/Programming/occt/OCCT/work/wasm/inc/
+  extra-lib-dirs:
+      /home/joseph/Programming/occt/emsdk/upstream/lib/
+      /home/joseph/Programming/occt/OCCT/work/wasm/lib/
   cxx-sources:
       cpp/hs_Bnd_Box.cpp
       cpp/hs_Bnd_OBB.cpp
@@ -451,7 +455,36 @@ library
       cpp/hs_XCAFDoc_ShapeTool.cpp
       cpp/hs_XSControl_Reader.cpp
   extra-libraries:
-      stdc++
+      c++
+      c++abi
+      TKGeomBase
+      TKStd
+      TKG3d
+      TKG2d
+      TKHLR
+      TKMath
+      TKernel
+      TKBRep
+      TKOffset
+      TKFillet
+      TKBO
+      TKPrim
+      TKTopAlgo
+      TKDESTL
+      TKDESTEP
+      TKDEGLTF
+      TKDEOBJ
+      TKV3d
+      TKMesh
+      TKRWMesh
+      TKLCAF
+      TKXCAF
+      TKService
+      TKShHealing
+      TKXSBase
+  extra-libraries-static:
+      c++
+      c++abi
       TKGeomBase
       TKStd
       TKG3d

--- a/scripts/occt/wasm_build.sh
+++ b/scripts/occt/wasm_build.sh
@@ -24,10 +24,9 @@ export BUILD_DataExchange=ON
 if [ -f "${aScriptDir}/wasm_custom.sh" ] ; then
   . "${aScriptDir}/wasm_custom.sh"
 fi
+source ~/.ghc-wasm/env
 
-. "${EMSDK_ROOT}/emsdk_env.sh"
-
-export aToolchain="${EMSDK}/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake"
+export aToolchain=~/.ghc-wasm/wasi-sdk/share/cmake/wasi-sdk.cmake
 
 export aGitBranch=`git symbolic-ref --short HEAD`
 
@@ -82,7 +81,8 @@ echo cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE:FILEPATH="${aToolchain}" \
 -DBUILD_MODULE_ApplicationFramework:BOOL="${BUILD_ApplicationFramework}" \
 -DBUILD_MODULE_DataExchange:BOOL="${BUILD_DataExchange}" \
 -DBUILD_MODULE_Draw:BOOL="OFF" \
--DBUILD_DOC_Overview:BOOL="OFF" "${aSrcRoot}"
+-DBUILD_DOC_Overview:BOOL="OFF" "${aSrcRoot}" \
+-DBUILD_RELEASE_DISABLE_EXCEPTIONS="ON"
 
 cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE:FILEPATH="${aToolchain}" \
 -DCMAKE_BUILD_TYPE:STRING="Release" \
@@ -107,7 +107,8 @@ cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE:FILEPATH="${aToolchain}" \
 -DBUILD_MODULE_ApplicationFramework:BOOL="${BUILD_ApplicationFramework}" \
 -DBUILD_MODULE_DataExchange:BOOL="${BUILD_DataExchange}" \
 -DBUILD_MODULE_Draw:BOOL="OFF" \
--DBUILD_DOC_Overview:BOOL="OFF" "${aSrcRoot}"
+-DBUILD_DOC_Overview:BOOL="OFF" "${aSrcRoot}" \
+-DBUILD_RELEASE_DISABLE_EXCEPTIONS="ON"
 
   if [ $? -ne 0 ]; then
     echo "Problem during configuration"

--- a/scripts/occt/wasm_build.sh
+++ b/scripts/occt/wasm_build.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+
+# Auxiliary script for semi-automated building of OCCT for WASM platform.
+# wasm_custom.sh should be configured with paths to CMake, 3rd-parties and Emscripten SDK.
+# FreeType should be specified as mandatory dependency.
+
+export aScriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+export aSrcRoot="${aScriptDir}/../.."
+export aBuildRoot=work
+
+export aNbJobs=${NUMBER_OF_PROCESSORS}
+
+export toCMake=1
+export toClean=0
+export toMake=1
+export toInstall=1
+
+export BUILD_ModelingData=ON
+export BUILD_ModelingAlgorithms=ON
+export BUILD_Visualization=ON
+export BUILD_ApplicationFramework=ON
+export BUILD_DataExchange=ON
+
+if [ -f "${aScriptDir}/wasm_custom.sh" ] ; then
+  . "${aScriptDir}/wasm_custom.sh"
+fi
+
+. "${EMSDK_ROOT}/emsdk_env.sh"
+
+export aToolchain="${EMSDK}/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake"
+
+export aGitBranch=`git symbolic-ref --short HEAD`
+
+echo "Compilation OCCT branch : $aGitBranch"
+
+export aPlatformAndCompiler=wasm
+
+export aWorkDir="${aSrcRoot}/${aBuildRoot}/${aPlatformAndCompiler}-make"
+if [ ! -d "${aWorkDir}" ]; then
+  mkdir -p "${aWorkDir}"
+fi
+
+export aDestDir="${aSrcRoot}/${aBuildRoot}/${aPlatformAndCompiler}"
+if [ ! -d "${aDestDir}" ]; then
+  mkdir -p "${aDestDir}"
+fi
+
+export aLogFile="${aSrcRoot}/${aBuildRoot}/build-${aPlatformAndCompiler}.log"
+if [ -f "${aLogFile}" ]; then
+  rm "${aLogFile}"
+fi
+
+echo Start building OCCT for ${aPlatformAndCompiler}
+echo Start building OCCT for ${aPlatformAndCompiler}>> "${aLogFile}"
+
+pushd "${aWorkDir}"
+pwd
+echo toCMake=${toCMake}
+if [ "${toCMake}" = "1" ]; then
+
+echo "Configuring OCCT for WASM..."
+echo cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE:FILEPATH="${aToolchain}" \
+-DCMAKE_BUILD_TYPE:STRING="Release" \
+-DBUILD_LIBRARY_TYPE:STRING="Static" \
+-DINSTALL_DIR:PATH="${aDestDir}" \
+-DINSTALL_DIR_INCLUDE:STRING="inc" \
+-DINSTALL_DIR_RESOURCE:STRING="src" \
+-D3RDPARTY_FREETYPE_DIR:PATH="$aFreeType" \
+-D3RDPARTY_FREETYPE_INCLUDE_DIR_freetype2:FILEPATH="$aFreeType/include" \
+-D3RDPARTY_FREETYPE_INCLUDE_DIR_ft2build:FILEPATH="$aFreeType/include" \
+-DUSE_RAPIDJSON:BOOL="ON" \
+-D3RDPARTY_RAPIDJSON_DIR:PATH="$aRapidJson" \
+-D3RDPARTY_RAPIDJSON_INCLUDE_DIR:PATH="$aRapidJson/include" \
+-DUSE_DRACO:BOOL="OFF" \
+-D3RDPARTY_DRACO_DIR:PATH="$aDraco" \
+-D3RDPARTY_DRACO_INCLUDE_DIR:FILEPATH="$aDraco/include" \
+-D3RDPARTY_DRACO_LIBRARY_DIR:PATH="$aDraco/lib" \
+-DBUILD_MODULE_FoundationClasses:BOOL="ON" \
+-DBUILD_MODULE_ModelingData:BOOL="${BUILD_ModelingData}" \
+-DBUILD_MODULE_ModelingAlgorithms:BOOL="${BUILD_ModelingAlgorithms}" \
+-DBUILD_MODULE_Visualization:BOOL="${BUILD_Visualization}" \
+-DBUILD_MODULE_ApplicationFramework:BOOL="${BUILD_ApplicationFramework}" \
+-DBUILD_MODULE_DataExchange:BOOL="${BUILD_DataExchange}" \
+-DBUILD_MODULE_Draw:BOOL="OFF" \
+-DBUILD_DOC_Overview:BOOL="OFF" "${aSrcRoot}"
+
+cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE:FILEPATH="${aToolchain}" \
+-DCMAKE_BUILD_TYPE:STRING="Release" \
+-DBUILD_LIBRARY_TYPE:STRING="Static" \
+-DINSTALL_DIR:PATH="${aDestDir}" \
+-DINSTALL_DIR_INCLUDE:STRING="inc" \
+-DINSTALL_DIR_RESOURCE:STRING="src" \
+-D3RDPARTY_FREETYPE_DIR:PATH="$aFreeType" \
+-D3RDPARTY_FREETYPE_INCLUDE_DIR_freetype2:FILEPATH="$aFreeType/include" \
+-D3RDPARTY_FREETYPE_INCLUDE_DIR_ft2build:FILEPATH="$aFreeType/include" \
+-DUSE_RAPIDJSON:BOOL="ON" \
+-D3RDPARTY_RAPIDJSON_DIR:PATH="$aRapidJson" \
+-D3RDPARTY_RAPIDJSON_INCLUDE_DIR:PATH="$aRapidJson/include" \
+-DUSE_DRACO:BOOL="OFF" \
+-D3RDPARTY_DRACO_DIR:PATH="$aDraco" \
+-D3RDPARTY_DRACO_INCLUDE_DIR:FILEPATH="$aDraco/include" \
+-D3RDPARTY_DRACO_LIBRARY_DIR:PATH="$aDraco/lib" \
+-DBUILD_MODULE_FoundationClasses:BOOL="ON" \
+-DBUILD_MODULE_ModelingData:BOOL="${BUILD_ModelingData}" \
+-DBUILD_MODULE_ModelingAlgorithms:BOOL="${BUILD_ModelingAlgorithms}" \
+-DBUILD_MODULE_Visualization:BOOL="${BUILD_Visualization}" \
+-DBUILD_MODULE_ApplicationFramework:BOOL="${BUILD_ApplicationFramework}" \
+-DBUILD_MODULE_DataExchange:BOOL="${BUILD_DataExchange}" \
+-DBUILD_MODULE_Draw:BOOL="OFF" \
+-DBUILD_DOC_Overview:BOOL="OFF" "${aSrcRoot}"
+
+  if [ $? -ne 0 ]; then
+    echo "Problem during configuration"
+    popd
+    exit 1
+  fi
+
+fi
+
+if [ "${toClean}" = "1" ]; then
+  make clean
+fi
+
+if [ "${toMake}" = "1" ]; then
+  echo Building...
+  make -j ${aNbJobs} 2>> "${aLogFile}"
+  if [ $? -ne 0 ]; then
+    echo "Problem during make operation"
+    popd
+    exit 1
+  fi
+  echo "${aLogFile}"
+fi
+
+if [ "${toInstall}" = "1" ]; then
+  echo Installing into ${aDestDir}
+  make install 2>> "${aLogFile}"
+fi
+
+popd

--- a/scripts/occt/wasm_custom.sh
+++ b/scripts/occt/wasm_custom.sh
@@ -1,6 +1,5 @@
 # environment configuration template for occ_build_wasm.sh (to be renamed as wasm_custom_env.sh)
 export aFreeType="$aSrcRoot/../freetype"
-export EMSDK_ROOT="$aSrcRoot/../emsdk"
 export aRapidJson="$aSrcRoot/../rapidjson"
 export aDraco="$aSrcRoot/../3rdparty/draco/build-dir/draco"
 # Uncomment to customize building steps

--- a/scripts/occt/wasm_custom.sh
+++ b/scripts/occt/wasm_custom.sh
@@ -1,0 +1,17 @@
+# environment configuration template for occ_build_wasm.sh (to be renamed as wasm_custom_env.sh)
+export aFreeType="$aSrcRoot/../freetype"
+export EMSDK_ROOT="$aSrcRoot/../emsdk"
+export aRapidJson="$aSrcRoot/../rapidjson"
+export aDraco="$aSrcRoot/../3rdparty/draco/build-dir/draco"
+# Uncomment to customize building steps
+#export aBuildRoot=work
+#export toCMake=1
+#export toClean=0
+#export toMake=1
+#export toInstall=1
+
+#export BUILD_ModelingData=ON
+#export BUILD_ModelingAlgorithms=ON
+#export BUILD_Visualization=ON
+#export BUILD_ApplicationFramework=ON
+#export BUILD_DataExchange=ON

--- a/waterfall-cad-examples/package.yaml
+++ b/waterfall-cad-examples/package.yaml
@@ -40,7 +40,6 @@ executables:
       waterfall-cad-examples
     source-dirs:         app
     ghc-options:
-    - -threaded
     - -rtsopts
     - -with-rtsopts=-N
 

--- a/waterfall-cad-examples/waterfall-cad-examples.cabal
+++ b/waterfall-cad-examples/waterfall-cad-examples.cabal
@@ -69,7 +69,8 @@ executable waterfall-cad-examples
       Paths_waterfall_cad_examples
   hs-source-dirs:
       app
-  ghc-options: -Wall -Werror=compat -Werror=identities -Werror=incomplete-record-updates -Werror=incomplete-uni-patterns -Werror=missing-home-modules -Werror=missing-export-lists -Werror=partial-fields -Werror=redundant-constraints -optc -Werror-implicit-function-declaration -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Werror=compat -Werror=identities -Werror=incomplete-record-updates -Werror=incomplete-uni-patterns -Werror=missing-home-modules -Werror=missing-export-lists -Werror=partial-fields -Werror=redundant-constraints -optc -Werror-implicit-function-declaration -rtsopts -with-rtsopts=-N
+  ld-options: -fwasm-exceptions
   build-depends:
       base >=4.7 && <5
     , lens ==5.*


### PR DESCRIPTION
If we were able to build Waterfall-CAD to wasm, then we would be able to build a website where you could run Waterfall-CAD programs in the browser (using ghc-api, [like in this project](https://discourse.haskell.org/t/ghc-now-runs-in-your-browser/13169/10)).

I imagine this being a little bit like [Thingiverse Customizer](https://www.thingiverse.com/app:22/screens). 

At the moment, I don't have this working, but this PR contains some of my work. 

---

I'm currently stuck on a couple of things:
a/ OpenCascade uses exceptions for error handling, and these are not supported by wasm32-wasi-ghc
b/ The wasm build of opencascade uses emscripten; emscripten and wasi-sdk are different things, and it's not clear to me that they play well together.
