### PR TITLE
Fix off-by-one in repeatLooping

### DIFF
--- a/waterfall-cad/src/Waterfall/TwoD/Path2D.hs
+++ b/waterfall-cad/src/Waterfall/TwoD/Path2D.hs
@@ -89,8 +89,8 @@ repeatLooping p =
             let a = unangle (e ^. _xy) - unangle (s ^. _xy)
             in if nearZero a 
                 then mempty
-                else let times :: Integer = abs . round $ pi * 2 / a 
-                      in mconcat $ [rotate2D (fromIntegral n * a) p | n <- [0..times]]
+                else let times :: Integer = round (pi * 2 / abs a)
+                      in mconcat [rotate2D (fromIntegral n * a) p | n <- [0 .. times-1]]
 
 
 -- $reexports


### PR DESCRIPTION
## Summary

- `repeatLooping` used `[0..times]` which produces `times + 1` elements, creating an overlapping duplicate of the first segment rotated by 360°
- Changed to `[0..times-1]` to generate exactly `times` copies

Fixes #35

## Test plan

- [x] Verified with `splitPath` that regular n-gons (n = 3, 4, 6, 8) produce exactly n segments, not n+1
- [x] `cabal build all` passes