### PR TITLE
Exception handling

### DIFF
--- a/opencascade-hs/CHANGELOG.md
+++ b/opencascade-hs/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to the
 
 ## Unreleased
 
+- Add `compose` and `composed` to `OpenCascade.TopoDS.Shape`
 - Add `normalized` and `normalize` to `OpenCascade.GP.Vec` and `OpenCascade.GP.Vec2d`
 
 ## 0.6.2.1

--- a/opencascade-hs/CHANGELOG.md
+++ b/opencascade-hs/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to the
 
 ## Unreleased
 
+- Add `normalized` and `normalize` to `OpenCascade.GP.Vec` and `OpenCascade.GP.Vec2d`
+
 ## 0.6.2.1
 
 ## 0.6.2.0

--- a/opencascade-hs/CHANGELOG.md
+++ b/opencascade-hs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to the
 
 - Add `compose` and `composed` to `OpenCascade.TopoDS.Shape`
 - Add `normalized` and `normalize` to `OpenCascade.GP.Vec` and `OpenCascade.GP.Vec2d`
+- Convert most FFI functions such that C++ exceptions thrown within them are converted into Haskell Exceptions
 
 ## 0.6.2.1
 

--- a/opencascade-hs/cpp/hs_BOPAlgo_BOP.cpp
+++ b/opencascade-hs/cpp/hs_BOPAlgo_BOP.cpp
@@ -1,4 +1,5 @@
 #include <BOPAlgo_BOP.hxx>
+#include "hs_Exception.h"
 #include "hs_BOPAlgo_BOP.h"
 
 
@@ -10,8 +11,17 @@ void hs_delete_BOPAlgo_BOP(BOPAlgo_BOP * bop){
     delete bop;
 }
 
-void hs_BOPAlgo_BOP_AddTool(BOPAlgo_BOP *bop, TopoDS_Shape * tool){
-    bop->AddTool(*tool);
+void hs_BOPAlgo_BOP_AddTool(
+        BOPAlgo_BOP *bop, TopoDS_Shape * tool,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [bop, tool]{
+            bop->AddTool(*tool);
+        }
+    );
 }
 
 void hs_BOPAlgo_BOP_SetOperation(BOPAlgo_BOP *bop, BOPAlgo_Operation operation){

--- a/opencascade-hs/cpp/hs_BOPAlgo_BOP.h
+++ b/opencascade-hs/cpp/hs_BOPAlgo_BOP.h
@@ -11,7 +11,10 @@ BOPAlgo_BOP * hs_new_BOPAlgo_BOP();
 
 void hs_delete_BOPAlgo_BOP(BOPAlgo_BOP * bop);
 
-void hs_BOPAlgo_BOP_AddTool(BOPAlgo_BOP *bop, TopoDS_Shape * tool);
+void hs_BOPAlgo_BOP_AddTool(
+    BOPAlgo_BOP *bop, TopoDS_Shape * tool,
+    HSExceptionType* exType, void ** exPtr
+);
 
 void hs_BOPAlgo_BOP_SetOperation(BOPAlgo_BOP *bop, BOPAlgo_Operation operation);
 

--- a/opencascade-hs/cpp/hs_BOPAlgo_Builder.cpp
+++ b/opencascade-hs/cpp/hs_BOPAlgo_Builder.cpp
@@ -1,4 +1,5 @@
 #include <BOPAlgo_Builder.hxx>
+#include "hs_Exception.h"
 #include "hs_BOPAlgo_Builder.h"
 
 BOPAlgo_Builder * hs_new_BOPAlgo_Builder(){
@@ -9,19 +10,46 @@ void hs_delete_BOPAlgo_Builder(BOPAlgo_Builder * builder){
     delete builder;
 }
 
-void hs_BOPAlgo_Builder_AddArgument(BOPAlgo_Builder * builder, TopoDS_Shape * shape){
-    builder->AddArgument(*shape);
+void hs_BOPAlgo_Builder_AddArgument(
+        BOPAlgo_Builder * builder, TopoDS_Shape * shape,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [builder, shape]{
+        builder->AddArgument(*shape);
+    });
 }
 
-TopoDS_Shape * hs_BOPAlgo_Builder_Shape(BOPAlgo_Builder * builder){
-    return new TopoDS_Shape(builder->Shape());
+TopoDS_Shape * hs_BOPAlgo_Builder_Shape(
+        BOPAlgo_Builder * builder,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [builder]{
+        return new TopoDS_Shape(builder->Shape());
+    });
 }
 
 void hs_BOPAlgo_Builder_SetRunParallel(BOPAlgo_Builder * builder, bool runParallel){
     builder->SetRunParallel(runParallel);
 }
 
-void hs_BOPAlgo_Builder_Perform(BOPAlgo_Builder * builder){
-    builder->Perform();
+void hs_BOPAlgo_Builder_Perform(
+        BOPAlgo_Builder * builder,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [builder]{
+        builder->Perform();
+    });
 }
 

--- a/opencascade-hs/cpp/hs_BOPAlgo_Builder.h
+++ b/opencascade-hs/cpp/hs_BOPAlgo_Builder.h
@@ -11,13 +11,25 @@ BOPAlgo_Builder * hs_new_BOPAlgo_Builder();
 
 void hs_delete_BOPAlgo_Builder(BOPAlgo_Builder * builder);
 
-void hs_BOPAlgo_Builder_AddArgument(BOPAlgo_Builder * builder, TopoDS_Shape * shape);
+void hs_BOPAlgo_Builder_AddArgument(
+    BOPAlgo_Builder * builder, TopoDS_Shape * shape,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-TopoDS_Shape * hs_BOPAlgo_Builder_Shape(BOPAlgo_Builder * builder);
+TopoDS_Shape * hs_BOPAlgo_Builder_Shape(
+    BOPAlgo_Builder * builder,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 void hs_BOPAlgo_Builder_SetRunParallel(BOPAlgo_Builder * builder, bool runParallel);
 
-void hs_BOPAlgo_Builder_Perform(BOPAlgo_Builder * builder);
+void hs_BOPAlgo_Builder_Perform(
+    BOPAlgo_Builder * builder,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_BRepAdaptor_Curve.cpp
+++ b/opencascade-hs/cpp/hs_BRepAdaptor_Curve.cpp
@@ -1,9 +1,19 @@
 #include <GeomAbs_CurveType.hxx>
 #include <BRepAdaptor_Curve.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepAdaptor_Curve.h"
 
-BRepAdaptor_Curve * hs_new_BRepAdaptor_Curve_fromEdge(TopoDS_Edge * edge){
-    return new BRepAdaptor_Curve(*edge);
+BRepAdaptor_Curve * hs_new_BRepAdaptor_Curve_fromEdge(
+        TopoDS_Edge * edge,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [edge]{
+            return new BRepAdaptor_Curve(*edge);
+        }
+    );
 }
 
 void hs_delete_BRepAdaptor_Curve(BRepAdaptor_Curve * curve){
@@ -14,16 +24,43 @@ GeomAbs_CurveType hs_BRepAdaptor_Curve_curveType(BRepAdaptor_Curve* curve){
     return curve->GetType();   
 }
 
-Handle(Geom_BezierCurve) * hs_BRepAdaptor_Curve_bezier(BRepAdaptor_Curve * curve){
-    return new opencascade::handle(curve->Bezier());
+Handle(Geom_BezierCurve) * hs_BRepAdaptor_Curve_bezier(
+        BRepAdaptor_Curve * curve,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [curve]{
+            return new opencascade::handle(curve->Bezier());
+        }
+    );
 }
 
-Handle(Geom_BSplineCurve) * hs_BRepAdaptor_Curve_bspline(BRepAdaptor_Curve * curve){
-    return new opencascade::handle(curve->BSpline());
+Handle(Geom_BSplineCurve) * hs_BRepAdaptor_Curve_bspline(
+        BRepAdaptor_Curve * curve,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [curve]{
+            return new opencascade::handle(curve->BSpline());
+        }
+    );
 }
 
-GeomAdaptor_Curve * hs_BRepAdaptor_Curve_curve(BRepAdaptor_Curve * curve){
-    return new GeomAdaptor_Curve(curve->Curve());
+GeomAdaptor_Curve * hs_BRepAdaptor_Curve_curve(
+        BRepAdaptor_Curve * curve,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [curve]{
+            return new GeomAdaptor_Curve(curve->Curve());
+        }
+    );
 }
 
 double hs_BRepAdaptor_Curve_firstParameter(BRepAdaptor_Curve *curve){

--- a/opencascade-hs/cpp/hs_BRepAdaptor_Curve.h
+++ b/opencascade-hs/cpp/hs_BRepAdaptor_Curve.h
@@ -7,17 +7,29 @@
 extern "C" {
 #endif
 
-BRepAdaptor_Curve * hs_new_BRepAdaptor_Curve_fromEdge(TopoDS_Edge * edge);
+BRepAdaptor_Curve * hs_new_BRepAdaptor_Curve_fromEdge(
+    TopoDS_Edge * edge,
+    HSExceptionType* exType, void ** exPtr
+);
 
 void hs_delete_BRepAdaptor_Curve(BRepAdaptor_Curve * curve);
 
 GeomAbs_CurveType hs_BRepAdaptor_Curve_curveType(BRepAdaptor_Curve* curve);
 
-Handle(Geom_BezierCurve) * hs_BRepAdaptor_Curve_bezier(BRepAdaptor_Curve * curve);
+Handle(Geom_BezierCurve) * hs_BRepAdaptor_Curve_bezier(
+    BRepAdaptor_Curve * curve,
+    HSExceptionType* exType, void ** exPtr
+);
 
-Handle(Geom_BSplineCurve) * hs_BRepAdaptor_Curve_bspline(BRepAdaptor_Curve * curve);
+Handle(Geom_BSplineCurve) * hs_BRepAdaptor_Curve_bspline(
+    BRepAdaptor_Curve * curve,
+    HSExceptionType* exType, void ** exPtr
+);
 
-GeomAdaptor_Curve * hs_BRepAdaptor_Curve_curve(BRepAdaptor_Curve * curve);
+GeomAdaptor_Curve * hs_BRepAdaptor_Curve_curve(
+    BRepAdaptor_Curve * curve,
+    HSExceptionType* exType, void ** exPtr
+);
 
 double hs_BRepAdaptor_Curve_firstParameter(BRepAdaptor_Curve *curve);
 

--- a/opencascade-hs/cpp/hs_BRepAlgoAPI_Common.cpp
+++ b/opencascade-hs/cpp/hs_BRepAlgoAPI_Common.cpp
@@ -1,9 +1,19 @@
 #include <BRepAlgoAPI_Common.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepAlgoAPI_Common.h"
 
 #include <TopoDS_Shape.hxx>
 
-TopoDS_Shape * hs_BRepAlgoAPI_Common(TopoDS_Shape * a, TopoDS_Shape * b){
-    auto builder = BRepAlgoAPI_Common(*a, *b);
-    return new TopoDS_Shape(builder.Shape());
+TopoDS_Shape * hs_BRepAlgoAPI_Common(
+        TopoDS_Shape * a, TopoDS_Shape * b,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [a, b]{
+        auto builder = BRepAlgoAPI_Common(*a, *b);
+        return new TopoDS_Shape(builder.Shape());
+    });
 }

--- a/opencascade-hs/cpp/hs_BRepAlgoAPI_Common.h
+++ b/opencascade-hs/cpp/hs_BRepAlgoAPI_Common.h
@@ -8,7 +8,11 @@
 extern "C" {
 #endif
 
-TopoDS_Shape * hs_BRepAlgoAPI_Common(TopoDS_Shape * a, TopoDS_Shape * b);
+TopoDS_Shape * hs_BRepAlgoAPI_Common(
+    TopoDS_Shape * a, TopoDS_Shape * b,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_BRepAlgoAPI_Cut.cpp
+++ b/opencascade-hs/cpp/hs_BRepAlgoAPI_Cut.cpp
@@ -1,9 +1,19 @@
 #include <BRepAlgoAPI_Cut.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepAlgoAPI_Cut.h"
 
 #include <TopoDS_Shape.hxx>
 
-TopoDS_Shape * hs_BRepAlgoAPI_Cut(TopoDS_Shape * a, TopoDS_Shape * b){
-    auto builder = BRepAlgoAPI_Cut(*a, *b);
-    return new TopoDS_Shape(builder.Shape());
+TopoDS_Shape * hs_BRepAlgoAPI_Cut(
+        TopoDS_Shape * a, TopoDS_Shape * b,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [a, b]{
+        auto builder = BRepAlgoAPI_Cut(*a, *b);
+        return new TopoDS_Shape(builder.Shape());
+    });
 }

--- a/opencascade-hs/cpp/hs_BRepAlgoAPI_Cut.h
+++ b/opencascade-hs/cpp/hs_BRepAlgoAPI_Cut.h
@@ -8,7 +8,11 @@
 extern "C" {
 #endif
 
-TopoDS_Shape * hs_BRepAlgoAPI_Cut(TopoDS_Shape * a, TopoDS_Shape * b);
+TopoDS_Shape * hs_BRepAlgoAPI_Cut(
+    TopoDS_Shape * a, TopoDS_Shape * b,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_BRepAlgoAPI_Fuse.cpp
+++ b/opencascade-hs/cpp/hs_BRepAlgoAPI_Fuse.cpp
@@ -1,9 +1,19 @@
 #include <BRepAlgoAPI_Fuse.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepAlgoAPI_Fuse.h"
 
 #include <TopoDS_Shape.hxx>
 
-TopoDS_Shape * hs_BRepAlgoAPI_Fuse(TopoDS_Shape * a, TopoDS_Shape * b){
-    auto builder = BRepAlgoAPI_Fuse(*a, *b);
-    return new TopoDS_Shape(builder.Shape());
+TopoDS_Shape * hs_BRepAlgoAPI_Fuse(
+        TopoDS_Shape * a, TopoDS_Shape * b,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [a, b]{
+        auto builder = BRepAlgoAPI_Fuse(*a, *b);
+        return new TopoDS_Shape(builder.Shape());
+    });
 }

--- a/opencascade-hs/cpp/hs_BRepAlgoAPI_Fuse.h
+++ b/opencascade-hs/cpp/hs_BRepAlgoAPI_Fuse.h
@@ -7,7 +7,11 @@
 extern "C" {
 #endif
 
-TopoDS_Shape * hs_BRepAlgoAPI_Fuse(TopoDS_Shape * a, TopoDS_Shape * b);
+TopoDS_Shape * hs_BRepAlgoAPI_Fuse(
+    TopoDS_Shape * a, TopoDS_Shape * b,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_BRepBndLib.cpp
+++ b/opencascade-hs/cpp/hs_BRepBndLib.cpp
@@ -1,14 +1,42 @@
 #include <BRepBndLib.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepBndLib.h"
 
-void hs_BRepBndLib_add(TopoDS_Shape * shape, Bnd_Box * box, bool useTriangulation){
-    BRepBndLib::Add(*shape, *box, useTriangulation);
+void hs_BRepBndLib_add(
+        TopoDS_Shape * shape, Bnd_Box * box, bool useTriangulation,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [shape, box, useTriangulation]{
+            BRepBndLib::Add(*shape, *box, useTriangulation);
+        }
+    );
 }
 
-void hs_BRepBndLib_addOptimal(TopoDS_Shape * shape, Bnd_Box * box, bool useTriangulation, bool useShapeTolerance){
-    BRepBndLib::AddOptimal(*shape, *box, useTriangulation, useShapeTolerance);
+void hs_BRepBndLib_addOptimal(
+        TopoDS_Shape * shape, Bnd_Box * box, bool useTriangulation, bool useShapeTolerance,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [shape, box, useTriangulation, useShapeTolerance]{
+            BRepBndLib::AddOptimal(*shape, *box, useTriangulation, useShapeTolerance);
+        }
+    );
 }
 
-void hs_BRepBndLib_addOBB(TopoDS_Shape *shape, Bnd_OBB * obb, bool isTriangulationUsed, bool isOptimal, bool isShapeToleranceUsed){
-    BRepBndLib::AddOBB(*shape, *obb, isTriangulationUsed, isOptimal, isShapeToleranceUsed);
+void hs_BRepBndLib_addOBB(
+        TopoDS_Shape *shape, Bnd_OBB * obb, bool isTriangulationUsed, bool isOptimal, bool isShapeToleranceUsed,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [shape, obb, isTriangulationUsed, isOptimal, isShapeToleranceUsed]{
+            BRepBndLib::AddOBB(*shape, *obb, isTriangulationUsed, isOptimal, isShapeToleranceUsed);
+        }
+    );
 }

--- a/opencascade-hs/cpp/hs_BRepBndLib.h
+++ b/opencascade-hs/cpp/hs_BRepBndLib.h
@@ -7,11 +7,20 @@
 extern "C" {
 #endif
 
-void hs_BRepBndLib_add(TopoDS_Shape * shape, Bnd_Box * box, bool useTriangulation);
+void hs_BRepBndLib_add(
+    TopoDS_Shape * shape, Bnd_Box * box, bool useTriangulation,
+    HSExceptionType* exType, void ** exPtr
+);
 
-void hs_BRepBndLib_addOptimal(TopoDS_Shape * shape, Bnd_Box * box, bool useTriangulation, bool useShapeTolerance);
+void hs_BRepBndLib_addOptimal(
+    TopoDS_Shape * shape, Bnd_Box * box, bool useTriangulation, bool useShapeTolerance,
+    HSExceptionType* exType, void ** exPtr
+);
 
-void hs_BRepBndLib_addOBB(TopoDS_Shape *shape, Bnd_OBB * obb, bool isTriangulationUsed, bool isOptimal, bool isShapeToleranceUsed);
+void hs_BRepBndLib_addOBB(
+    TopoDS_Shape *shape, Bnd_OBB * obb, bool isTriangulationUsed, bool isOptimal, bool isShapeToleranceUsed,
+    HSExceptionType* exType, void ** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_BRepBuilderAPI_Copy.cpp
+++ b/opencascade-hs/cpp/hs_BRepBuilderAPI_Copy.cpp
@@ -1,6 +1,16 @@
 #include <BRepBuilderAPI_Copy.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepBuilderAPI_Copy.h"
 
-TopoDS_Shape * hs_BRepBuilderAPI_Copy_copy(TopoDS_Shape *shape, bool copyGeom, bool copyMesh){
-    return new TopoDS_Shape(BRepBuilderAPI_Copy(*shape, copyGeom, copyMesh).Shape());
+TopoDS_Shape * hs_BRepBuilderAPI_Copy_copy(
+        TopoDS_Shape *shape, bool copyGeom, bool copyMesh,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [shape, copyGeom, copyMesh]{
+        return new TopoDS_Shape(BRepBuilderAPI_Copy(*shape, copyGeom, copyMesh).Shape());
+    });
 }

--- a/opencascade-hs/cpp/hs_BRepBuilderAPI_Copy.h
+++ b/opencascade-hs/cpp/hs_BRepBuilderAPI_Copy.h
@@ -8,7 +8,11 @@
 extern "C" {
 #endif
 
-TopoDS_Shape * hs_BRepBuilderAPI_Copy_copy(TopoDS_Shape *shape, bool copyGeom, bool copyMesh);
+TopoDS_Shape * hs_BRepBuilderAPI_Copy_copy(
+    TopoDS_Shape *shape, bool copyGeom, bool copyMesh,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_BRepBuilderAPI_GTransform.cpp
+++ b/opencascade-hs/cpp/hs_BRepBuilderAPI_GTransform.cpp
@@ -1,10 +1,20 @@
 #include <BRepBuilderAPI_GTransform.hxx>
 #include <TopoDS_Shape.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepBuilderAPI_GTransform.h"
 
-TopoDS_Shape * hs_BRepBuilderAPI_GTransform_gtransform(TopoDS_Shape * shape, gp_GTrsf * trsf, bool copy){
-    auto builder = BRepBuilderAPI_GTransform(*shape, *trsf, copy);
-    return new TopoDS_Shape(builder.Shape());
+TopoDS_Shape * hs_BRepBuilderAPI_GTransform_gtransform(
+        TopoDS_Shape * shape, gp_GTrsf * trsf, bool copy,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [shape, trsf, copy]{
+        auto builder = BRepBuilderAPI_GTransform(*shape, *trsf, copy);
+        return new TopoDS_Shape(builder.Shape());
+    });
 }
 
 

--- a/opencascade-hs/cpp/hs_BRepBuilderAPI_GTransform.h
+++ b/opencascade-hs/cpp/hs_BRepBuilderAPI_GTransform.h
@@ -7,7 +7,11 @@
 extern "C" {
 #endif
 
-TopoDS_Shape * hs_BRepBuilderAPI_GTransform_gtransform(TopoDS_Shape * shape, gp_GTrsf * trsf, bool copy);
+TopoDS_Shape * hs_BRepBuilderAPI_GTransform_gtransform(
+    TopoDS_Shape * shape, gp_GTrsf * trsf, bool copy,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_BRepBuilderAPI_MakeEdge.cpp
+++ b/opencascade-hs/cpp/hs_BRepBuilderAPI_MakeEdge.cpp
@@ -1,36 +1,111 @@
 #include <BRepBuilderAPI_MakeEdge.hxx>
 #include <TopoDS_Edge.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepBuilderAPI_MakeEdge.h"
 
-TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromVertices(TopoDS_Vertex *a, TopoDS_Vertex *b){
-    return new TopoDS_Edge(BRepBuilderAPI_MakeEdge(*a, *b));
+TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromVertices(TopoDS_Vertex *a, TopoDS_Vertex *b,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    
+    return hs_handleEx(
+        exType, 
+        exPtr,
+        [a, b]{ 
+        return new TopoDS_Edge(BRepBuilderAPI_MakeEdge(*a, *b));
+    });
 }
 
-TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromPnts(gp_Pnt *a, gp_Pnt *b){
-    return new TopoDS_Edge(BRepBuilderAPI_MakeEdge(*a, *b));
+TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromPnts(
+        gp_Pnt *a, gp_Pnt *b,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType, 
+        exPtr,
+        [a, b]{ 
+        return new TopoDS_Edge(BRepBuilderAPI_MakeEdge(*a, *b));
+    });
 }
 
-TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromCurve(Handle(Geom_Curve) * curve){
-    return new TopoDS_Edge(BRepBuilderAPI_MakeEdge(*curve));
+TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromCurve(
+        Handle(Geom_Curve) * curve,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType, 
+        exPtr,
+        [curve]{ 
+        return new TopoDS_Edge(BRepBuilderAPI_MakeEdge(*curve));
+    });
 }
 
-TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromCurveAndParameters(Handle(Geom_Curve) * curve, double a, double b){
-    return new TopoDS_Edge(BRepBuilderAPI_MakeEdge(*curve, a, b));
+TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromCurveAndParameters(
+        Handle(Geom_Curve) * curve, double a, double b,
+        HSExceptionType* exType,
+        void** exPtr
+    ){
+    return hs_handleEx(
+        exType, 
+        exPtr,
+        [curve, a, b]{ 
+        return new TopoDS_Edge(BRepBuilderAPI_MakeEdge(*curve, a, b));
+    });
 }
 
-TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromCurveAndVertices(Handle(Geom_Curve) * curve, TopoDS_Vertex* a, TopoDS_Vertex* b){
-    return new TopoDS_Edge(BRepBuilderAPI_MakeEdge(*curve, *a, *b));
+TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromCurveAndVertices(
+        Handle(Geom_Curve) * curve, TopoDS_Vertex* a, TopoDS_Vertex* b, 
+        HSExceptionType* exType,
+        void** exPtr
+    ){
+    return hs_handleEx(
+        exType, 
+        exPtr,
+        [curve, a, b]{ 
+        return new TopoDS_Edge(BRepBuilderAPI_MakeEdge(*curve, *a, *b));
+    });
 }
 
-TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromCurveAndPnts(Handle(Geom_Curve) * curve, gp_Pnt* a, gp_Pnt* b){
-    return new TopoDS_Edge(BRepBuilderAPI_MakeEdge(*curve, *a, *b));
+TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromCurveAndPnts(
+        Handle(Geom_Curve) * curve, gp_Pnt* a, gp_Pnt* b, 
+        HSExceptionType* exType,
+        void** exPtr
+    ){
+        
+    return hs_handleEx(
+        exType, 
+        exPtr,
+        [curve, a, b]{ 
+        return new TopoDS_Edge(BRepBuilderAPI_MakeEdge(*curve, *a, *b));
+    });
 }
 
-TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromCurveVerticesAndParameters(Handle(Geom_Curve) * curve, TopoDS_Vertex* a, TopoDS_Vertex* b, double ap, double bp){
-    return new TopoDS_Edge(BRepBuilderAPI_MakeEdge(*curve, *a, *b, ap, bp));
+TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromCurveVerticesAndParameters(
+        Handle(Geom_Curve) * curve, TopoDS_Vertex* a, TopoDS_Vertex* b, double ap, double bp,
+        HSExceptionType* exType,
+        void** exPtr
+    ){
+        
+    return hs_handleEx(
+        exType, 
+        exPtr,
+        [curve, a, b, ap, bp]{ 
+        return new TopoDS_Edge(BRepBuilderAPI_MakeEdge(*curve, *a, *b, ap, bp));
+    });
 }
 
 
-TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromCurvePntsAndParameters(Handle(Geom_Curve) * curve, gp_Pnt* a, gp_Pnt* b, double ap, double bp){
-    return new TopoDS_Edge(BRepBuilderAPI_MakeEdge(*curve, *a, *b, ap, bp));
+TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromCurvePntsAndParameters(
+        Handle(Geom_Curve) * curve, gp_Pnt* a, gp_Pnt* b, double ap, double bp, 
+        HSExceptionType* exType,
+        void** exPtr
+    ){
+    return hs_handleEx(
+        exType, 
+        exPtr,
+        [curve, a, b, ap, bp]{ 
+        return new TopoDS_Edge(BRepBuilderAPI_MakeEdge(*curve, *a, *b, ap, bp));
+    });
 }

--- a/opencascade-hs/cpp/hs_BRepBuilderAPI_MakeEdge.h
+++ b/opencascade-hs/cpp/hs_BRepBuilderAPI_MakeEdge.h
@@ -7,21 +7,53 @@
 extern "C" {
 #endif
 
-TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromVertices(TopoDS_Vertex *a, TopoDS_Vertex *b);
+TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromVertices(
+    TopoDS_Vertex *a, TopoDS_Vertex *b, 
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromPnts(gp_Pnt *a, gp_Pnt *b);
+TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromPnts(
+    gp_Pnt *a, gp_Pnt *b, 
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromCurve(Handle(Geom_Curve) * curve);
+TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromCurve(
+    Handle(Geom_Curve) * curve, 
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromCurveAndParameters(Handle(Geom_Curve) * curve, double a, double b);
+TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromCurveAndParameters(
+    Handle(Geom_Curve) * curve, double a, double b,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromCurveAndVertices(Handle(Geom_Curve) * curve, TopoDS_Vertex* a, TopoDS_Vertex* b);
+TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromCurveAndVertices(
+    Handle(Geom_Curve) * curve, TopoDS_Vertex* a, TopoDS_Vertex* b,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromCurveAndPnts(Handle(Geom_Curve) * curve, gp_Pnt* a, gp_Pnt* b);
+TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromCurveAndPnts(
+    Handle(Geom_Curve) * curve, gp_Pnt* a, gp_Pnt* b,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromCurveVerticesAndParameters(Handle(Geom_Curve) * curve, TopoDS_Vertex* a, TopoDS_Vertex* b, double ap, double bp);
+TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromCurveVerticesAndParameters(
+    Handle(Geom_Curve) * curve, TopoDS_Vertex* a, TopoDS_Vertex* b, double ap, double bp, 
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromCurvePntsAndParameters(Handle(Geom_Curve) * curve, gp_Pnt* a, gp_Pnt* b, double ap, double bp);
+TopoDS_Edge * hs_BRepBuilderAPI_MakeEdge_fromCurvePntsAndParameters(
+    Handle(Geom_Curve) * curve, gp_Pnt* a, gp_Pnt* b, double ap, double bp,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_BRepBuilderAPI_MakeFace.cpp
+++ b/opencascade-hs/cpp/hs_BRepBuilderAPI_MakeFace.cpp
@@ -1,5 +1,6 @@
 #include <BRepBuilderAPI_MakeFace.hxx>
 #include <TopoDS_Face.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepBuilderAPI_MakeFace.h"
 
 BRepBuilderAPI_MakeFace * hs_new_BRepBuilderAPI_MakeFace(){
@@ -10,28 +11,82 @@ void hs_delete_BRepBuilderAPI_MakeFace(BRepBuilderAPI_MakeFace * builder){
     delete builder;
 }
 
-BRepBuilderAPI_MakeFace * hs_new_BRepBuilderAPI_MakeFace_fromFace(TopoDS_Face * face){
-    return new BRepBuilderAPI_MakeFace(*face);
+BRepBuilderAPI_MakeFace * hs_new_BRepBuilderAPI_MakeFace_fromFace(
+        TopoDS_Face * face,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [face]{
+        return new BRepBuilderAPI_MakeFace(*face);
+    });
 }
 
-BRepBuilderAPI_MakeFace * hs_new_BRepBuilderAPI_MakeFace_fromSurface(Handle(Geom_Surface)* surface, double tolerance){
-    return new BRepBuilderAPI_MakeFace(*surface, tolerance);
+BRepBuilderAPI_MakeFace * hs_new_BRepBuilderAPI_MakeFace_fromSurface(
+        Handle(Geom_Surface)* surface, double tolerance,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [surface, tolerance]{
+        return new BRepBuilderAPI_MakeFace(*surface, tolerance);
+    });
 }
 
-BRepBuilderAPI_MakeFace * hs_new_BRepBuilderAPI_MakeFace_fromSurfaceAndBounds(Handle(Geom_Surface)* surface, double uMin, double uMax, double vMin, double vMax, double tolerance){
-    return new BRepBuilderAPI_MakeFace(*surface, uMin, uMax, vMin, vMax, tolerance);
+BRepBuilderAPI_MakeFace * hs_new_BRepBuilderAPI_MakeFace_fromSurfaceAndBounds(
+        Handle(Geom_Surface)* surface, double uMin, double uMax, double vMin, double vMax, double tolerance,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [surface, uMin, uMax, vMin, vMax, tolerance]{
+        return new BRepBuilderAPI_MakeFace(*surface, uMin, uMax, vMin, vMax, tolerance);
+    });
 }
 
-BRepBuilderAPI_MakeFace * hs_new_BRepBuilderAPI_MakeFace_fromSurfaceAndWire(Handle(Geom_Surface)* surface, TopoDS_Wire* wire, bool inside){
-    return new BRepBuilderAPI_MakeFace(*surface, *wire, inside);
+BRepBuilderAPI_MakeFace * hs_new_BRepBuilderAPI_MakeFace_fromSurfaceAndWire(
+        Handle(Geom_Surface)* surface, TopoDS_Wire* wire, bool inside,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [surface, wire, inside]{
+        return new BRepBuilderAPI_MakeFace(*surface, *wire, inside);
+    });
 }
 
-BRepBuilderAPI_MakeFace * hs_new_BRepBuilderAPI_MakeFace_fromWire(TopoDS_Wire* wire, bool onlyPlane){
-    return new BRepBuilderAPI_MakeFace(*wire, onlyPlane);
+BRepBuilderAPI_MakeFace * hs_new_BRepBuilderAPI_MakeFace_fromWire(
+        TopoDS_Wire* wire, bool onlyPlane,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [wire, onlyPlane]{
+        return new BRepBuilderAPI_MakeFace(*wire, onlyPlane);
+    });
 }
 
-void hs_BRepBuilderAPI_MakeFace_Add(BRepBuilderAPI_MakeFace* builder, TopoDS_Wire* wire){
-    builder->Add(*wire);
+void hs_BRepBuilderAPI_MakeFace_Add(
+        BRepBuilderAPI_MakeFace* builder, TopoDS_Wire* wire,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [builder, wire]{
+        builder->Add(*wire);
+    });
 }
 
 bool hs_BRepBuilderAPI_MakeFace_IsDone(BRepBuilderAPI_MakeFace* builder){
@@ -42,6 +97,15 @@ BRepBuilderAPI_FaceError hs_BRepBuilderAPI_MakeFace_Error(BRepBuilderAPI_MakeFac
     return builder->Error();
 }
 
-TopoDS_Face * hs_BRepBuilderAPI_MakeFace_Face(BRepBuilderAPI_MakeFace * builder){
-    return new TopoDS_Face(builder->Face());
+TopoDS_Face * hs_BRepBuilderAPI_MakeFace_Face(
+        BRepBuilderAPI_MakeFace * builder,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [builder]{
+        return new TopoDS_Face(builder->Face());
+    });
 }

--- a/opencascade-hs/cpp/hs_BRepBuilderAPI_MakeFace.h
+++ b/opencascade-hs/cpp/hs_BRepBuilderAPI_MakeFace.h
@@ -11,23 +11,51 @@ BRepBuilderAPI_MakeFace * hs_new_BRepBuilderAPI_MakeFace();
 
 void hs_delete_BRepBuilderAPI_MakeFace(BRepBuilderAPI_MakeFace * builder);
 
-BRepBuilderAPI_MakeFace * hs_new_BRepBuilderAPI_MakeFace_fromFace(TopoDS_Face * face);
+BRepBuilderAPI_MakeFace * hs_new_BRepBuilderAPI_MakeFace_fromFace(
+    TopoDS_Face * face,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-BRepBuilderAPI_MakeFace * hs_new_BRepBuilderAPI_MakeFace_fromSurface(Handle(Geom_Surface)* surface, double tolerance);
+BRepBuilderAPI_MakeFace * hs_new_BRepBuilderAPI_MakeFace_fromSurface(
+    Handle(Geom_Surface)* surface, double tolerance,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-BRepBuilderAPI_MakeFace * hs_new_BRepBuilderAPI_MakeFace_fromSurfaceAndBounds(Handle(Geom_Surface)* surface, double uMin, double uMax, double vMin, double vMax, double tolerance);
+BRepBuilderAPI_MakeFace * hs_new_BRepBuilderAPI_MakeFace_fromSurfaceAndBounds(
+    Handle(Geom_Surface)* surface, double uMin, double uMax, double vMin, double vMax, double tolerance,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-BRepBuilderAPI_MakeFace * hs_new_BRepBuilderAPI_MakeFace_fromSurfaceAndWire(Handle(Geom_Surface)* surface, TopoDS_Wire* wire, bool inside);
+BRepBuilderAPI_MakeFace * hs_new_BRepBuilderAPI_MakeFace_fromSurfaceAndWire(
+    Handle(Geom_Surface)* surface, TopoDS_Wire* wire, bool inside,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-BRepBuilderAPI_MakeFace * hs_new_BRepBuilderAPI_MakeFace_fromWire(TopoDS_Wire* wire, bool onlyPlane);
+BRepBuilderAPI_MakeFace * hs_new_BRepBuilderAPI_MakeFace_fromWire(
+    TopoDS_Wire* wire, bool onlyPlane,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-void hs_BRepBuilderAPI_MakeFace_Add(BRepBuilderAPI_MakeFace* builder, TopoDS_Wire* wire);
+void hs_BRepBuilderAPI_MakeFace_Add(
+    BRepBuilderAPI_MakeFace* builder, TopoDS_Wire* wire,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 bool hs_BRepBuilderAPI_MakeFace_IsDone(BRepBuilderAPI_MakeFace* builder);
 
 BRepBuilderAPI_FaceError hs_BRepBuilderAPI_MakeFace_Error(BRepBuilderAPI_MakeFace * builder);
 
-TopoDS_Face * hs_BRepBuilderAPI_MakeFace_Face(BRepBuilderAPI_MakeFace * builder);
+TopoDS_Face * hs_BRepBuilderAPI_MakeFace_Face(
+    BRepBuilderAPI_MakeFace * builder,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_BRepBuilderAPI_MakePolygon.cpp
+++ b/opencascade-hs/cpp/hs_BRepBuilderAPI_MakePolygon.cpp
@@ -1,8 +1,18 @@
 #include <BRepBuilderAPI_MakePolygon.hxx>
 #include <TopoDS_Wire.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepBuilderAPI_MakePolygon.h"
 
-TopoDS_Wire * hs_BRepBuilderAPI_MakePolygon_from3Pnts(gp_Pnt * n1, gp_Pnt *n2, gp_Pnt * n3, bool close){
-    auto builder = BRepBuilderAPI_MakePolygon(*n1, *n2, *n3, close);
-    return new TopoDS_Wire(builder.Wire());
+TopoDS_Wire * hs_BRepBuilderAPI_MakePolygon_from3Pnts(
+        gp_Pnt * n1, gp_Pnt *n2, gp_Pnt * n3, bool close,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [n1, n2, n3, close]{
+        auto builder = BRepBuilderAPI_MakePolygon(*n1, *n2, *n3, close);
+        return new TopoDS_Wire(builder.Wire());
+    });
 }

--- a/opencascade-hs/cpp/hs_BRepBuilderAPI_MakePolygon.h
+++ b/opencascade-hs/cpp/hs_BRepBuilderAPI_MakePolygon.h
@@ -7,7 +7,11 @@
     extern "C" {
 #endif
 
-TopoDS_Wire * hs_BRepBuilderAPI_MakePolygon_from3Pnts(gp_Pnt * n1, gp_Pnt *n2, gp_Pnt * n3, bool close);
+TopoDS_Wire * hs_BRepBuilderAPI_MakePolygon_from3Pnts(
+    gp_Pnt * n1, gp_Pnt *n2, gp_Pnt * n3, bool close,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 #ifdef __cplusplus
     }

--- a/opencascade-hs/cpp/hs_BRepBuilderAPI_MakeShape.cpp
+++ b/opencascade-hs/cpp/hs_BRepBuilderAPI_MakeShape.cpp
@@ -1,11 +1,36 @@
 #include <BRepBuilderAPI_MakeShape.hxx>
 #include <TopoDS_Shape.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepBuilderAPI_MakeShape.h"
 
-TopoDS_Shape * hs_BRepBuilderAPI_MakeShape_shape(BRepBuilderAPI_MakeShape* builder){
-    return new TopoDS_Shape(builder->Shape());
+TopoDS_Shape * hs_BRepBuilderAPI_MakeShape_shape(
+        BRepBuilderAPI_MakeShape* builder,
+        HSExceptionType* exType,
+        void** exPtr
+
+    ){
+        
+    return hs_handleEx(
+        exType, 
+        exPtr,
+        [builder]{ 
+            return new TopoDS_Shape(
+                builder->Shape()
+            );
+        }
+    );
 }
 
-void hs_BRepBuilderAPI_MakeShape_build(BRepBuilderAPI_MakeShape* builder){
-    builder->Build();
+void hs_BRepBuilderAPI_MakeShape_build(
+        BRepBuilderAPI_MakeShape* builder, 
+        HSExceptionType* exType,
+        void** exPtr
+    ){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [builder]{
+            builder->Build();
+        }
+    );
 }

--- a/opencascade-hs/cpp/hs_BRepBuilderAPI_MakeShape.h
+++ b/opencascade-hs/cpp/hs_BRepBuilderAPI_MakeShape.h
@@ -7,9 +7,17 @@
 extern "C" {
 #endif
 
-TopoDS_Shape * hs_BRepBuilderAPI_MakeShape_shape(BRepBuilderAPI_MakeShape * builder);
+TopoDS_Shape * hs_BRepBuilderAPI_MakeShape_shape(
+    BRepBuilderAPI_MakeShape * builder,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-void hs_BRepBuilderAPI_MakeShape_build(BRepBuilderAPI_MakeShape* builder);
+void hs_BRepBuilderAPI_MakeShape_build(
+        BRepBuilderAPI_MakeShape* builder, 
+        HSExceptionType* exType,
+        void** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_BRepBuilderAPI_MakeSolid.cpp
+++ b/opencascade-hs/cpp/hs_BRepBuilderAPI_MakeSolid.cpp
@@ -1,5 +1,6 @@
 #include <BRepBuilderAPI_MakeSolid.hxx>
 #include <TopoDS_Solid.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepBuilderAPI_MakeSolid.h"
 
 BRepBuilderAPI_MakeSolid * hs_new_BRepBuilderAPI_MakeSolid(){
@@ -11,10 +12,28 @@ void hs_delete_BRepBuilderAPI_MakeSolid(BRepBuilderAPI_MakeSolid * builder){
     delete builder;
 }
 
-void hs_BRepBuilderAPI_MakeSolid_add(BRepBuilderAPI_MakeSolid * builder, TopoDS_Shell * shell){
-    builder->Add(*shell);
+void hs_BRepBuilderAPI_MakeSolid_add(
+        BRepBuilderAPI_MakeSolid * builder, TopoDS_Shell * shell,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [builder, shell]{
+        builder->Add(*shell);
+    });
 }
 
-TopoDS_Solid * hs_BRepBuilderAPI_MakeSolid_solid(BRepBuilderAPI_MakeSolid * builder){
-    return new TopoDS_Solid(builder->Solid());
+TopoDS_Solid * hs_BRepBuilderAPI_MakeSolid_solid(
+        BRepBuilderAPI_MakeSolid * builder,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [builder]{
+        return new TopoDS_Solid(builder->Solid());
+    });
 }

--- a/opencascade-hs/cpp/hs_BRepBuilderAPI_MakeSolid.h
+++ b/opencascade-hs/cpp/hs_BRepBuilderAPI_MakeSolid.h
@@ -11,9 +11,17 @@ BRepBuilderAPI_MakeSolid * hs_new_BRepBuilderAPI_MakeSolid();
 
 void hs_delete_BRepBuilderAPI_MakeSolid(BRepBuilderAPI_MakeSolid * builder);
 
-void hs_BRepBuilderAPI_MakeSolid_add(BRepBuilderAPI_MakeSolid * builder, TopoDS_Shell * shell);
+void hs_BRepBuilderAPI_MakeSolid_add(
+    BRepBuilderAPI_MakeSolid * builder, TopoDS_Shell * shell,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-TopoDS_Solid * hs_BRepBuilderAPI_MakeSolid_solid(BRepBuilderAPI_MakeSolid * builder);
+TopoDS_Solid * hs_BRepBuilderAPI_MakeSolid_solid(
+    BRepBuilderAPI_MakeSolid * builder,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_BRepBuilderAPI_MakeVertex.cpp
+++ b/opencascade-hs/cpp/hs_BRepBuilderAPI_MakeVertex.cpp
@@ -1,15 +1,34 @@
 #include <BRepBuilderAPI_MakeVertex.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepBuilderAPI_MakeVertex.h"
 #include <TopoDS_Vertex.hxx>
 
-BRepBuilderAPI_MakeVertex * hs_new_BRepBuilderAPI_MakeVertex_fromPnt(gp_Pnt* pnt){
-    return new BRepBuilderAPI_MakeVertex(*pnt);
+BRepBuilderAPI_MakeVertex * hs_new_BRepBuilderAPI_MakeVertex_fromPnt(
+        gp_Pnt* pnt,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [pnt]{
+        return new BRepBuilderAPI_MakeVertex(*pnt);
+    });
 }
 
 void hs_delete_BRepBuilderAPI_MakeVertex(BRepBuilderAPI_MakeVertex* builder){
     delete builder;
 }
 
-TopoDS_Vertex * hs_BRepBuilderAPI_MakeVertex_vertex(BRepBuilderAPI_MakeVertex * builder){
-    return new TopoDS_Vertex(builder->Vertex());
+TopoDS_Vertex * hs_BRepBuilderAPI_MakeVertex_vertex(
+        BRepBuilderAPI_MakeVertex * builder,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [builder]{
+        return new TopoDS_Vertex(builder->Vertex());
+    });
 }

--- a/opencascade-hs/cpp/hs_BRepBuilderAPI_MakeVertex.h
+++ b/opencascade-hs/cpp/hs_BRepBuilderAPI_MakeVertex.h
@@ -7,11 +7,19 @@
 extern "C" {
 #endif
 
-BRepBuilderAPI_MakeVertex * hs_new_BRepBuilderAPI_MakeVertex_fromPnt(gp_Pnt* pnt);
+BRepBuilderAPI_MakeVertex * hs_new_BRepBuilderAPI_MakeVertex_fromPnt(
+    gp_Pnt* pnt,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 void hs_delete_BRepBuilderAPI_MakeVertex(BRepBuilderAPI_MakeVertex* builder);
 
-TopoDS_Vertex * hs_BRepBuilderAPI_MakeVertex_vertex(BRepBuilderAPI_MakeVertex * builder);
+TopoDS_Vertex * hs_BRepBuilderAPI_MakeVertex_vertex(
+    BRepBuilderAPI_MakeVertex * builder,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_BRepBuilderAPI_MakeWire.cpp
+++ b/opencascade-hs/cpp/hs_BRepBuilderAPI_MakeWire.cpp
@@ -1,5 +1,6 @@
 #include <BRepBuilderAPI_MakeWire.hxx>
 #include <TopoDS_Wire.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepBuilderAPI_MakeWire.h"
 
 BRepBuilderAPI_MakeWire * hs_new_BRepBuilderAPI_MakeWire(){
@@ -10,24 +11,69 @@ void hs_delete_BRepBuilderAPI_MakeWire(BRepBuilderAPI_MakeWire* builder){
     delete builder;
 }
 
-void hs_BRepBuilderAPI_MakeWire_AddEdge(BRepBuilderAPI_MakeWire* builder, TopoDS_Edge* edge){
-    builder->Add(*edge);
+void hs_BRepBuilderAPI_MakeWire_AddEdge(
+        BRepBuilderAPI_MakeWire* builder, TopoDS_Edge* edge,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [builder, edge]{
+        builder->Add(*edge);
+    });
 }
 
-void hs_BRepBuilderAPI_MakeWire_AddWire(BRepBuilderAPI_MakeWire* builder, TopoDS_Wire* wire){
-    builder->Add(*wire);
+void hs_BRepBuilderAPI_MakeWire_AddWire(
+        BRepBuilderAPI_MakeWire* builder, TopoDS_Wire* wire,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [builder, wire]{
+        builder->Add(*wire);
+    });
 }
 
-void hs_BRepBuilderAPI_MakeWire_AddListOfShape(BRepBuilderAPI_MakeWire* builder, TopTools_ListOfShape *list){
-    builder->Add(*list);
+void hs_BRepBuilderAPI_MakeWire_AddListOfShape(
+        BRepBuilderAPI_MakeWire* builder, TopTools_ListOfShape *list,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [builder, list]{
+        builder->Add(*list);
+    });
 }
 
-TopoDS_Wire * hs_BRepBuilderAPI_MakeWire_Wire(BRepBuilderAPI_MakeWire* builder){
-    return new TopoDS_Wire(builder->Wire());
+TopoDS_Wire * hs_BRepBuilderAPI_MakeWire_Wire(
+        BRepBuilderAPI_MakeWire* builder,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [builder]{
+        return new TopoDS_Wire(builder->Wire());
+    });
 }
 
-TopoDS_Vertex * hs_BRepBuilderAPI_MakeWire_Vertex(BRepBuilderAPI_MakeWire* builder){
-    return new TopoDS_Vertex(builder->Vertex());
+TopoDS_Vertex * hs_BRepBuilderAPI_MakeWire_Vertex(
+        BRepBuilderAPI_MakeWire* builder,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [builder]{
+        return new TopoDS_Vertex(builder->Vertex());
+    });
 }
 
 bool hs_BRepBuilderAPI_MakeWire_IsDone(BRepBuilderAPI_MakeWire* builder){

--- a/opencascade-hs/cpp/hs_BRepBuilderAPI_MakeWire.h
+++ b/opencascade-hs/cpp/hs_BRepBuilderAPI_MakeWire.h
@@ -11,15 +11,35 @@ BRepBuilderAPI_MakeWire * hs_new_BRepBuilderAPI_MakeWire();
 
 void hs_delete_BRepBuilderAPI_MakeWire(BRepBuilderAPI_MakeWire* builder);
 
-void hs_BRepBuilderAPI_MakeWire_AddEdge(BRepBuilderAPI_MakeWire* builder, TopoDS_Edge* edge);
+void hs_BRepBuilderAPI_MakeWire_AddEdge(
+    BRepBuilderAPI_MakeWire* builder, TopoDS_Edge* edge,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-void hs_BRepBuilderAPI_MakeWire_AddWire(BRepBuilderAPI_MakeWire* builder, TopoDS_Wire* wire);
+void hs_BRepBuilderAPI_MakeWire_AddWire(
+    BRepBuilderAPI_MakeWire* builder, TopoDS_Wire* wire,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-void hs_BRepBuilderAPI_MakeWire_AddListOfShape(BRepBuilderAPI_MakeWire* builder, TopTools_ListOfShape *list);
+void hs_BRepBuilderAPI_MakeWire_AddListOfShape(
+    BRepBuilderAPI_MakeWire* builder, TopTools_ListOfShape *list,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-TopoDS_Wire * hs_BRepBuilderAPI_MakeWire_Wire(BRepBuilderAPI_MakeWire* builder);
+TopoDS_Wire * hs_BRepBuilderAPI_MakeWire_Wire(
+    BRepBuilderAPI_MakeWire* builder,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-TopoDS_Vertex * hs_BRepBuilderAPI_MakeWire_Vertex(BRepBuilderAPI_MakeWire* builder);
+TopoDS_Vertex * hs_BRepBuilderAPI_MakeWire_Vertex(
+    BRepBuilderAPI_MakeWire* builder,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 bool hs_BRepBuilderAPI_MakeWire_IsDone(BRepBuilderAPI_MakeWire* builder);
 

--- a/opencascade-hs/cpp/hs_BRepBuilderAPI_Sewing.cpp
+++ b/opencascade-hs/cpp/hs_BRepBuilderAPI_Sewing.cpp
@@ -1,4 +1,5 @@
 #include <BRepBuilderAPI_Sewing.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepBuilderAPI_Sewing.h"
 
 BRepBuilderAPI_Sewing * hs_new_BRepBuilderAPI_Sewing(double tolerance , bool option1, bool option2, bool option3, bool option4){
@@ -9,20 +10,56 @@ void hs_delete_BRepBuilderAPI_Sewing(BRepBuilderAPI_Sewing * builder){
     delete builder;
 }
 
-void hs_BRepBuilderAPI_Sewing_load(BRepBuilderAPI_Sewing * builder, TopoDS_Shape * shape){
-    builder->Load(*shape);
+void hs_BRepBuilderAPI_Sewing_load(
+        BRepBuilderAPI_Sewing * builder, TopoDS_Shape * shape,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [builder, shape]{
+        builder->Load(*shape);
+    });
 }
 
-void hs_BRepBuilderAPI_Sewing_add(BRepBuilderAPI_Sewing * builder, TopoDS_Shape * shape){
-    builder->Add(*shape);
+void hs_BRepBuilderAPI_Sewing_add(
+        BRepBuilderAPI_Sewing * builder, TopoDS_Shape * shape,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [builder, shape]{
+        builder->Add(*shape);
+    });
 }
 
-void hs_BRepBuilderAPI_Sewing_perform(BRepBuilderAPI_Sewing * builder){
-    builder->Perform();
+void hs_BRepBuilderAPI_Sewing_perform(
+        BRepBuilderAPI_Sewing * builder,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [builder]{
+        builder->Perform();
+    });
 }
 
-TopoDS_Shape * hs_BRepBuilderAPI_Sewing_sewedShape(BRepBuilderAPI_Sewing * builder){
-    return new TopoDS_Shape(builder->SewedShape());
+TopoDS_Shape * hs_BRepBuilderAPI_Sewing_sewedShape(
+        BRepBuilderAPI_Sewing * builder,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [builder]{
+        return new TopoDS_Shape(builder->SewedShape());
+    });
 }
 
 

--- a/opencascade-hs/cpp/hs_BRepBuilderAPI_Sewing.h
+++ b/opencascade-hs/cpp/hs_BRepBuilderAPI_Sewing.h
@@ -11,13 +11,29 @@ BRepBuilderAPI_Sewing * hs_new_BRepBuilderAPI_Sewing(double tolerance , bool opt
 
 void hs_delete_BRepBuilderAPI_Sewing(BRepBuilderAPI_Sewing * builder);
 
-void hs_BRepBuilderAPI_Sewing_load(BRepBuilderAPI_Sewing * builder, TopoDS_Shape * shape);
+void hs_BRepBuilderAPI_Sewing_load(
+    BRepBuilderAPI_Sewing * builder, TopoDS_Shape * shape,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-void hs_BRepBuilderAPI_Sewing_add(BRepBuilderAPI_Sewing * builder, TopoDS_Shape * shape);
+void hs_BRepBuilderAPI_Sewing_add(
+    BRepBuilderAPI_Sewing * builder, TopoDS_Shape * shape,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-void hs_BRepBuilderAPI_Sewing_perform(BRepBuilderAPI_Sewing * builder);
+void hs_BRepBuilderAPI_Sewing_perform(
+    BRepBuilderAPI_Sewing * builder,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-TopoDS_Shape * hs_BRepBuilderAPI_Sewing_sewedShape(BRepBuilderAPI_Sewing * builder);
+TopoDS_Shape * hs_BRepBuilderAPI_Sewing_sewedShape(
+    BRepBuilderAPI_Sewing * builder,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 int hs_BRepBuilderAPI_Sewing_nbFreeEdges(BRepBuilderAPI_Sewing * builder);
 

--- a/opencascade-hs/cpp/hs_BRepBuilderAPI_Transform.cpp
+++ b/opencascade-hs/cpp/hs_BRepBuilderAPI_Transform.cpp
@@ -1,10 +1,20 @@
 #include <BRepBuilderAPI_Transform.hxx>
 #include <TopoDS_Shape.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepBuilderAPI_Transform.h"
 
-TopoDS_Shape * hs_BRepBuilderAPI_Transform_transform(TopoDS_Shape * shape, gp_Trsf * trsf, bool copy){
-    auto builder = BRepBuilderAPI_Transform(*shape, *trsf, copy);
-    return new TopoDS_Shape(builder.Shape());
+TopoDS_Shape * hs_BRepBuilderAPI_Transform_transform(
+        TopoDS_Shape * shape, gp_Trsf * trsf, bool copy,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [shape, trsf, copy]{
+        auto builder = BRepBuilderAPI_Transform(*shape, *trsf, copy);
+        return new TopoDS_Shape(builder.Shape());
+    });
 }
 
 

--- a/opencascade-hs/cpp/hs_BRepBuilderAPI_Transform.h
+++ b/opencascade-hs/cpp/hs_BRepBuilderAPI_Transform.h
@@ -7,7 +7,11 @@
 extern "C" {
 #endif
 
-TopoDS_Shape * hs_BRepBuilderAPI_Transform_transform(TopoDS_Shape * shape, gp_Trsf * trsf, bool copy);
+TopoDS_Shape * hs_BRepBuilderAPI_Transform_transform(
+    TopoDS_Shape * shape, gp_Trsf * trsf, bool copy,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_BRepFilletAPI_MakeChamfer.cpp
+++ b/opencascade-hs/cpp/hs_BRepFilletAPI_MakeChamfer.cpp
@@ -1,21 +1,49 @@
 #include <BRepFilletAPI_MakeChamfer.hxx>
 #include <TopoDS_Shape.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepFilletAPI_MakeChamfer.h"
 
-BRepFilletAPI_MakeChamfer * hs_new_BRepFilletAPI_MakeChamfer_fromShape(TopoDS_Shape * shape) {
-    return new BRepFilletAPI_MakeChamfer(*shape);
+BRepFilletAPI_MakeChamfer * hs_new_BRepFilletAPI_MakeChamfer_fromShape(
+        TopoDS_Shape * shape,
+        HSExceptionType* exType,
+        void** exPtr
+) {
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [shape]{
+        return new BRepFilletAPI_MakeChamfer(*shape);
+    });
 }
 
 void hs_delete_BRepFilletAPI_MakeChamfer(BRepFilletAPI_MakeChamfer * builder) {
     delete builder;
 }
 
-void hs_BRepFilletAPI_MakeChamfer_addEdge(BRepFilletAPI_MakeChamfer * builder, TopoDS_Edge *edge ){
-    builder->Add(*edge);
+void hs_BRepFilletAPI_MakeChamfer_addEdge(
+        BRepFilletAPI_MakeChamfer * builder, TopoDS_Edge *edge,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [builder, edge]{
+        builder->Add(*edge);
+    });
 }
 
-void hs_BRepFilletAPI_MakeChamfer_addEdgeWithDistance(BRepFilletAPI_MakeChamfer * builder, double d, TopoDS_Edge *edge ){
-    builder->Add(d, *edge);
+void hs_BRepFilletAPI_MakeChamfer_addEdgeWithDistance(
+        BRepFilletAPI_MakeChamfer * builder, double d, TopoDS_Edge *edge,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [builder, d, edge]{
+        builder->Add(d, *edge);
+    });
 }
 
 void hs_BRepFilletAPI_MakeChamfer_reset(BRepFilletAPI_MakeChamfer * builder){
@@ -26,10 +54,28 @@ int hs_BRepFilletAPI_MakeChamfer_nbEdges(BRepFilletAPI_MakeChamfer * builder, in
     return builder->NbEdges(contourIndex);
 }
 
-TopoDS_Edge * hs_BRepFilletAPI_MakeChamfer_edge(BRepFilletAPI_MakeChamfer * builder, int contourIndex, int edgeIndex){
-    return new TopoDS_Edge(builder->Edge(contourIndex, edgeIndex));
+TopoDS_Edge * hs_BRepFilletAPI_MakeChamfer_edge(
+        BRepFilletAPI_MakeChamfer * builder, int contourIndex, int edgeIndex,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [builder, contourIndex, edgeIndex]{
+        return new TopoDS_Edge(builder->Edge(contourIndex, edgeIndex));
+    });
 }
 
-void hs_BRepFilletAPI_MakeChamfer_remove(BRepFilletAPI_MakeChamfer * builder, TopoDS_Edge * edge){
-    builder->Remove(*edge);
+void hs_BRepFilletAPI_MakeChamfer_remove(
+        BRepFilletAPI_MakeChamfer * builder, TopoDS_Edge * edge,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [builder, edge]{
+        builder->Remove(*edge);
+    });
 }

--- a/opencascade-hs/cpp/hs_BRepFilletAPI_MakeChamfer.h
+++ b/opencascade-hs/cpp/hs_BRepFilletAPI_MakeChamfer.h
@@ -7,21 +7,41 @@
 extern "C" {
 #endif
 
-BRepFilletAPI_MakeChamfer * hs_new_BRepFilletAPI_MakeChamfer_fromShape(TopoDS_Shape * shape) ;
+BRepFilletAPI_MakeChamfer * hs_new_BRepFilletAPI_MakeChamfer_fromShape(
+    TopoDS_Shape * shape,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 void hs_delete_BRepFilletAPI_MakeChamfer(BRepFilletAPI_MakeChamfer * builder) ;
 
-void hs_BRepFilletAPI_MakeChamfer_addEdge(BRepFilletAPI_MakeChamfer * builder, TopoDS_Edge *edge );
+void hs_BRepFilletAPI_MakeChamfer_addEdge(
+    BRepFilletAPI_MakeChamfer * builder, TopoDS_Edge *edge,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-void hs_BRepFilletAPI_MakeChamfer_addEdgeWithDistance(BRepFilletAPI_MakeChamfer * builder, double d, TopoDS_Edge *edge );
+void hs_BRepFilletAPI_MakeChamfer_addEdgeWithDistance(
+    BRepFilletAPI_MakeChamfer * builder, double d, TopoDS_Edge *edge,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 void hs_BRepFilletAPI_MakeChamfer_reset(BRepFilletAPI_MakeChamfer * builder);
 
 int hs_BRepFilletAPI_MakeChamfer_nbEdges(BRepFilletAPI_MakeChamfer * builder, int contourIndex);
 
-TopoDS_Edge * hs_BRepFilletAPI_MakeChamfer_edge(BRepFilletAPI_MakeChamfer * builder, int contourIndex, int edgeIndex);
+TopoDS_Edge * hs_BRepFilletAPI_MakeChamfer_edge(
+    BRepFilletAPI_MakeChamfer * builder, int contourIndex, int edgeIndex,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-void hs_BRepFilletAPI_MakeChamfer_remove(BRepFilletAPI_MakeChamfer * builder, TopoDS_Edge * edge);
+void hs_BRepFilletAPI_MakeChamfer_remove(
+    BRepFilletAPI_MakeChamfer * builder, TopoDS_Edge * edge,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_BRepFilletAPI_MakeFillet.cpp
+++ b/opencascade-hs/cpp/hs_BRepFilletAPI_MakeFillet.cpp
@@ -1,25 +1,62 @@
 #include <BRepFilletAPI_MakeFillet.hxx>
 #include <TopoDS_Shape.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepFilletAPI_MakeFillet.h"
 
-BRepFilletAPI_MakeFillet * hs_new_BRepFilletAPI_MakeFillet_fromShape(TopoDS_Shape * shape) {
-    return new BRepFilletAPI_MakeFillet(*shape);
+BRepFilletAPI_MakeFillet * hs_new_BRepFilletAPI_MakeFillet_fromShape(
+        TopoDS_Shape * shape,
+        HSExceptionType* exType,
+        void** exPtr
+) {
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [shape]{
+        return new BRepFilletAPI_MakeFillet(*shape);
+    });
 }
 
 void hs_delete_BRepFilletAPI_MakeFillet(BRepFilletAPI_MakeFillet * builder) {
     delete builder;
 }
 
-void hs_BRepFilletAPI_MakeFillet_addEdge(BRepFilletAPI_MakeFillet * builder, TopoDS_Edge *edge ){
-    builder->Add(*edge);
+void hs_BRepFilletAPI_MakeFillet_addEdge(
+        BRepFilletAPI_MakeFillet * builder, TopoDS_Edge *edge,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [builder, edge]{
+        builder->Add(*edge);
+    });
 }
 
-void hs_BRepFilletAPI_MakeFillet_addEdgeWithRadius(BRepFilletAPI_MakeFillet * builder, double r, TopoDS_Edge *edge ){
-    builder->Add(r, *edge);
+void hs_BRepFilletAPI_MakeFillet_addEdgeWithRadius(
+        BRepFilletAPI_MakeFillet * builder, double r, TopoDS_Edge *edge,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [builder, r, edge]{
+        builder->Add(r, *edge);
+    });
 }
 
-void hs_BRepFilletAPI_MakeFillet_addEdgeWithTwoRadiuses(BRepFilletAPI_MakeFillet * builder, double r1, double r2, TopoDS_Edge *edge ){
-    builder->Add(r1, r2, *edge);
+void hs_BRepFilletAPI_MakeFillet_addEdgeWithTwoRadiuses(
+        BRepFilletAPI_MakeFillet * builder, double r1, double r2, TopoDS_Edge *edge,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [builder, r1, r2, edge]{
+        builder->Add(r1, r2, *edge);
+    });
 }
 
 void hs_BRepFilletAPI_MakeFillet_reset(BRepFilletAPI_MakeFillet * builder){
@@ -38,10 +75,28 @@ int hs_BRepFilletAPI_MakeFillet_nbEdges(BRepFilletAPI_MakeFillet * builder, int 
     return builder->NbEdges(contourIndex);
 }
 
-TopoDS_Edge * hs_BRepFilletAPI_MakeFillet_edge(BRepFilletAPI_MakeFillet * builder, int contourIndex, int edgeIndex){
-    return new TopoDS_Edge(builder->Edge(contourIndex, edgeIndex));
+TopoDS_Edge * hs_BRepFilletAPI_MakeFillet_edge(
+        BRepFilletAPI_MakeFillet * builder, int contourIndex, int edgeIndex,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [builder, contourIndex, edgeIndex]{
+        return new TopoDS_Edge(builder->Edge(contourIndex, edgeIndex));
+    });
 }
 
-void hs_BRepFilletAPI_MakeFillet_remove(BRepFilletAPI_MakeFillet * builder, TopoDS_Edge * edge){
-    builder->Remove(*edge);
+void hs_BRepFilletAPI_MakeFillet_remove(
+        BRepFilletAPI_MakeFillet * builder, TopoDS_Edge * edge,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [builder, edge]{
+        builder->Remove(*edge);
+    });
 }

--- a/opencascade-hs/cpp/hs_BRepFilletAPI_MakeFillet.h
+++ b/opencascade-hs/cpp/hs_BRepFilletAPI_MakeFillet.h
@@ -7,15 +7,31 @@
 extern "C" {
 #endif
 
-BRepFilletAPI_MakeFillet * hs_new_BRepFilletAPI_MakeFillet_fromShape(TopoDS_Shape * shape);
+BRepFilletAPI_MakeFillet * hs_new_BRepFilletAPI_MakeFillet_fromShape(
+    TopoDS_Shape * shape,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 void hs_delete_BRepFilletAPI_MakeFillet(BRepFilletAPI_MakeFillet * builder);
 
-void hs_BRepFilletAPI_MakeFillet_addEdge(BRepFilletAPI_MakeFillet * builder, TopoDS_Edge *edge );
+void hs_BRepFilletAPI_MakeFillet_addEdge(
+    BRepFilletAPI_MakeFillet * builder, TopoDS_Edge *edge,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-void hs_BRepFilletAPI_MakeFillet_addEdgeWithRadius(BRepFilletAPI_MakeFillet * builder, double r, TopoDS_Edge *edge );
+void hs_BRepFilletAPI_MakeFillet_addEdgeWithRadius(
+    BRepFilletAPI_MakeFillet * builder, double r, TopoDS_Edge *edge,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-void hs_BRepFilletAPI_MakeFillet_addEdgeWithTwoRadiuses(BRepFilletAPI_MakeFillet * builder, double r1, double r2, TopoDS_Edge *edge );
+void hs_BRepFilletAPI_MakeFillet_addEdgeWithTwoRadiuses(
+    BRepFilletAPI_MakeFillet * builder, double r1, double r2, TopoDS_Edge *edge,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 void hs_BRepFilletAPI_MakeFillet_reset(BRepFilletAPI_MakeFillet * builder);
 
@@ -25,9 +41,17 @@ int hs_BRepFilletAPI_MakeFillet_faultyContour(BRepFilletAPI_MakeFillet * builder
 
 int hs_BRepFilletAPI_MakeFillet_nbEdges(BRepFilletAPI_MakeFillet * builder, int contourIndex);
 
-TopoDS_Edge * hs_BRepFilletAPI_MakeFillet_edge(BRepFilletAPI_MakeFillet * builder, int contourIndex, int edgeIndex);
+TopoDS_Edge * hs_BRepFilletAPI_MakeFillet_edge(
+    BRepFilletAPI_MakeFillet * builder, int contourIndex, int edgeIndex,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-void hs_BRepFilletAPI_MakeFillet_remove(BRepFilletAPI_MakeFillet * builder, TopoDS_Edge * edge);
+void hs_BRepFilletAPI_MakeFillet_remove(
+    BRepFilletAPI_MakeFillet * builder, TopoDS_Edge * edge,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_BRepGProp.cpp
+++ b/opencascade-hs/cpp/hs_BRepGProp.cpp
@@ -1,14 +1,42 @@
 #include <BRepGProp.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepGProp.h"
 
-void hs_BRepGProp_VolumeProperties(TopoDS_Shape *shape, GProp_GProps *props, bool onlyClosed, bool skipShared, bool useTriangulation ){
-    BRepGProp::VolumeProperties(*shape, *props, onlyClosed, skipShared, useTriangulation);
+void hs_BRepGProp_VolumeProperties(
+        TopoDS_Shape *shape, GProp_GProps *props, bool onlyClosed, bool skipShared, bool useTriangulation,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [shape, props, onlyClosed, skipShared, useTriangulation]{
+            BRepGProp::VolumeProperties(*shape, *props, onlyClosed, skipShared, useTriangulation);
+        }
+    );
 }
 
-void hs_BRepGProp_SurfaceProperties(TopoDS_Shape *shape, GProp_GProps *props, bool skipShared, bool useTriangulation ){
-    BRepGProp::SurfaceProperties(*shape, *props, skipShared, useTriangulation);
+void hs_BRepGProp_SurfaceProperties(
+        TopoDS_Shape *shape, GProp_GProps *props, bool skipShared, bool useTriangulation,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [shape, props, skipShared, useTriangulation]{
+            BRepGProp::SurfaceProperties(*shape, *props, skipShared, useTriangulation);
+        }
+    );
 }
 
-void hs_BRepGProp_LinearProperties(TopoDS_Shape *shape, GProp_GProps *props, bool skipShared, bool useTriangulation ){
-    BRepGProp::LinearProperties(*shape, *props, skipShared, useTriangulation);
+void hs_BRepGProp_LinearProperties(
+        TopoDS_Shape *shape, GProp_GProps *props, bool skipShared, bool useTriangulation,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [shape, props, skipShared, useTriangulation]{
+            BRepGProp::LinearProperties(*shape, *props, skipShared, useTriangulation);
+        }
+    );
 }

--- a/opencascade-hs/cpp/hs_BRepGProp.h
+++ b/opencascade-hs/cpp/hs_BRepGProp.h
@@ -7,11 +7,20 @@
 extern "C" {
 #endif
 
-void hs_BRepGProp_VolumeProperties(TopoDS_Shape * shape, GProp_GProps * props, bool onlyClosed, bool skipShared, bool useTriangulation);
+void hs_BRepGProp_VolumeProperties(
+    TopoDS_Shape * shape, GProp_GProps * props, bool onlyClosed, bool skipShared, bool useTriangulation,
+    HSExceptionType* exType, void ** exPtr
+);
 
-void hs_BRepGProp_SurfaceProperties(TopoDS_Shape *shape, GProp_GProps *props, bool skipShared, bool useTriangulation);
+void hs_BRepGProp_SurfaceProperties(
+    TopoDS_Shape *shape, GProp_GProps *props, bool skipShared, bool useTriangulation,
+    HSExceptionType* exType, void ** exPtr
+);
 
-void hs_BRepGProp_LinearProperties(TopoDS_Shape *shape, GProp_GProps *props, bool skipShared, bool useTriangulation);
+void hs_BRepGProp_LinearProperties(
+    TopoDS_Shape *shape, GProp_GProps *props, bool skipShared, bool useTriangulation,
+    HSExceptionType* exType, void ** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_BRepLib.cpp
+++ b/opencascade-hs/cpp/hs_BRepLib.cpp
@@ -1,10 +1,31 @@
 #include <BRepLib.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepLib.h"
 
-bool hs_BRepLib_orientClosedSolid(TopoDS_Solid * solid){
-    return BRepLib::OrientClosedSolid(*solid);
+bool hs_BRepLib_orientClosedSolid(
+        TopoDS_Solid * solid,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleExWithDefault(
+        exType,
+        exPtr,
+        [solid]{
+            return BRepLib::OrientClosedSolid(*solid);
+        },
+        false
+    );
 }
 
-bool hs_BRepLib_buildCurve3d(TopoDS_Edge* edge, double tolerance, GeomAbs_Shape continuity, int maxDegree, int maxSegment){
-    return BRepLib::BuildCurve3d(*edge, tolerance, continuity, maxDegree, maxSegment);
+bool hs_BRepLib_buildCurve3d(
+        TopoDS_Edge* edge, double tolerance, GeomAbs_Shape continuity, int maxDegree, int maxSegment,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleExWithDefault(
+        exType,
+        exPtr,
+        [edge, tolerance, continuity, maxDegree, maxSegment]{
+            return BRepLib::BuildCurve3d(*edge, tolerance, continuity, maxDegree, maxSegment);
+        },
+        false
+    );
 }

--- a/opencascade-hs/cpp/hs_BRepLib.h
+++ b/opencascade-hs/cpp/hs_BRepLib.h
@@ -7,9 +7,15 @@
 extern "C" {
 #endif
 
-bool hs_BRepLib_orientClosedSolid(TopoDS_Solid * solid);
+bool hs_BRepLib_orientClosedSolid(
+    TopoDS_Solid * solid,
+    HSExceptionType* exType, void ** exPtr
+);
 
-bool hs_BRepLib_buildCurve3d(TopoDS_Edge* edge, double tolerance, GeomAbs_Shape continuity, int maxDegree, int maxSegment);
+bool hs_BRepLib_buildCurve3d(
+    TopoDS_Edge* edge, double tolerance, GeomAbs_Shape continuity, int maxDegree, int maxSegment,
+    HSExceptionType* exType, void ** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_BRepMesh_IncrementalMesh.cpp
+++ b/opencascade-hs/cpp/hs_BRepMesh_IncrementalMesh.cpp
@@ -1,15 +1,34 @@
 #include <BRepMesh_IncrementalMesh.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepMesh_IncrementalMesh.h"
 
 
-BRepMesh_IncrementalMesh * hs_BRepMesh_IncrementalMesh_fromShapeAndLinDeflection(TopoDS_Shape *shape, double theLinDeflection){
-    return new BRepMesh_IncrementalMesh(*shape, theLinDeflection);
+BRepMesh_IncrementalMesh * hs_BRepMesh_IncrementalMesh_fromShapeAndLinDeflection(
+        TopoDS_Shape *shape, double theLinDeflection,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [shape, theLinDeflection]{
+            return new BRepMesh_IncrementalMesh(*shape, theLinDeflection);
+        }
+    );
 }
 
 void hs_delete_BRepMesh_IncrementalMesh(BRepMesh_IncrementalMesh * mesh){
     delete mesh;
 }
 
-void hs_BRepMesh_IncrementalMesh_Perform(BRepMesh_IncrementalMesh * mesh){
-    mesh->Perform();
+void hs_BRepMesh_IncrementalMesh_Perform(
+        BRepMesh_IncrementalMesh * mesh,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [mesh]{
+            mesh->Perform();
+        }
+    );
 }

--- a/opencascade-hs/cpp/hs_BRepMesh_IncrementalMesh.h
+++ b/opencascade-hs/cpp/hs_BRepMesh_IncrementalMesh.h
@@ -7,11 +7,17 @@
 extern "C" {
 #endif
 
-BRepMesh_IncrementalMesh * hs_BRepMesh_IncrementalMesh_fromShapeAndLinDeflection(TopoDS_Shape *shape, double theLinDeflection);
+BRepMesh_IncrementalMesh * hs_BRepMesh_IncrementalMesh_fromShapeAndLinDeflection(
+    TopoDS_Shape *shape, double theLinDeflection,
+    HSExceptionType* exType, void ** exPtr
+);
 
 void hs_delete_BRepMesh_IncrementalMesh(BRepMesh_IncrementalMesh * mesh);
 
-void hs_BRepMesh_IncrementalMesh_Perform(BRepMesh_IncrementalMesh * mesh);
+void hs_BRepMesh_IncrementalMesh_Perform(
+    BRepMesh_IncrementalMesh * mesh,
+    HSExceptionType* exType, void ** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_BRepOffsetAPI_MakeOffsetShape.cpp
+++ b/opencascade-hs/cpp/hs_BRepOffsetAPI_MakeOffsetShape.cpp
@@ -10,8 +10,21 @@ void hs_delete_BRepOffsetAPI_MakeOffsetShape(BRepOffsetAPI_MakeOffsetShape * bui
     delete builder;
 }
 
-void hs_BRepOffsetAPI_MakeOffsetShape_performBySimple(BRepOffsetAPI_MakeOffsetShape * builder, TopoDS_Shape * shape, double value){
-    builder->PerformBySimple(*shape, value);
+void hs_BRepOffsetAPI_MakeOffsetShape_performBySimple(
+    BRepOffsetAPI_MakeOffsetShape * builder,
+    TopoDS_Shape * shape,
+    double value, 
+    HSExceptionType* exType,
+    void** exPtr
+    ){
+        
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [builder, shape, value]{
+            builder->PerformBySimple(*shape, value);
+        }
+    );
 }
 
 void hs_BRepOffsetAPI_MakeOffsetShape_performByJoin(

--- a/opencascade-hs/cpp/hs_BRepOffsetAPI_MakeOffsetShape.cpp
+++ b/opencascade-hs/cpp/hs_BRepOffsetAPI_MakeOffsetShape.cpp
@@ -1,5 +1,6 @@
 #include <BRepOffsetAPI_MakeOffsetShape.hxx>
 #include "hs_BRepOffsetAPI_MakeOffsetShape.h"
+#include "hs_Exception.h"
 
 BRepOffsetAPI_MakeOffsetShape * hs_new_BRepOffsetAPI_MakeOffsetShape(){
     return new BRepOffsetAPI_MakeOffsetShape();
@@ -22,7 +23,23 @@ void hs_BRepOffsetAPI_MakeOffsetShape_performByJoin(
     bool intersection,
     bool selfInter,
     GeomAbs_JoinType join,
-    bool removeIntEdges
+    bool removeIntEdges,
+    HSExceptionType* exType,
+    void* exPtr
      ){
-    builder->PerformByJoin(*shape, value, tol, mode, intersection, selfInter, join, removeIntEdges);
+    hs_handleEx(
+        exType,
+        exPtr,
+        builder,
+        &BRepOffsetAPI_MakeOffsetShape::PerformByJoin,
+        *shape,
+        value,
+        tol,
+        mode,
+        intersection,
+        selfInter,
+        join,
+        removeIntEdges,
+        Message_ProgressRange()
+    );
 }

--- a/opencascade-hs/cpp/hs_BRepOffsetAPI_MakeOffsetShape.cpp
+++ b/opencascade-hs/cpp/hs_BRepOffsetAPI_MakeOffsetShape.cpp
@@ -25,21 +25,22 @@ void hs_BRepOffsetAPI_MakeOffsetShape_performByJoin(
     GeomAbs_JoinType join,
     bool removeIntEdges,
     HSExceptionType* exType,
-    void* exPtr
+    void** exPtr
      ){
-    hs_handleEx(
+    hs_handleExVoid(
         exType,
         exPtr,
-        builder,
-        &BRepOffsetAPI_MakeOffsetShape::PerformByJoin,
-        *shape,
-        value,
-        tol,
-        mode,
-        intersection,
-        selfInter,
-        join,
-        removeIntEdges,
-        Message_ProgressRange()
+        [builder, shape, value, tol, mode, intersection, selfInter, join, removeIntEdges]{
+            builder->PerformByJoin(
+                *shape,
+                value,
+                tol,
+                mode,
+                intersection,
+                selfInter,
+                join,
+                removeIntEdges
+            );
+        }
     );
 }

--- a/opencascade-hs/cpp/hs_BRepOffsetAPI_MakeOffsetShape.h
+++ b/opencascade-hs/cpp/hs_BRepOffsetAPI_MakeOffsetShape.h
@@ -25,7 +25,7 @@ void hs_BRepOffsetAPI_MakeOffsetShape_performByJoin(
     GeomAbs_JoinType join,
     bool removeIntEdges,
     HSExceptionType* exType,
-    void* exPtr
+    void** exPtr
     );
 
 #ifdef __cplusplus

--- a/opencascade-hs/cpp/hs_BRepOffsetAPI_MakeOffsetShape.h
+++ b/opencascade-hs/cpp/hs_BRepOffsetAPI_MakeOffsetShape.h
@@ -12,7 +12,13 @@ BRepOffsetAPI_MakeOffsetShape * hs_new_BRepOffsetAPI_MakeOffsetShape();
 
 void hs_delete_BRepOffsetAPI_MakeOffsetShape(BRepOffsetAPI_MakeOffsetShape * builder);
 
-void hs_BRepOffsetAPI_MakeOffsetShape_performBySimple(BRepOffsetAPI_MakeOffsetShape * builder, TopoDS_Shape * shape, double value);
+void hs_BRepOffsetAPI_MakeOffsetShape_performBySimple(
+    BRepOffsetAPI_MakeOffsetShape * builder,
+    TopoDS_Shape * shape,
+    double value,
+    HSExceptionType* exType,
+    void** exPtr
+    );
 
 void hs_BRepOffsetAPI_MakeOffsetShape_performByJoin(
     BRepOffsetAPI_MakeOffsetShape * builder,

--- a/opencascade-hs/cpp/hs_BRepOffsetAPI_MakeOffsetShape.h
+++ b/opencascade-hs/cpp/hs_BRepOffsetAPI_MakeOffsetShape.h
@@ -2,6 +2,7 @@
 #define HS_BREPOFFSETAPI_MAKEOFFSETSHAPE_H
 
 #include "hs_types.h"
+#include "hs_Exception.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -22,7 +23,9 @@ void hs_BRepOffsetAPI_MakeOffsetShape_performByJoin(
     bool intersection,
     bool selfInter,
     GeomAbs_JoinType join,
-    bool removeIntEdges
+    bool removeIntEdges,
+    HSExceptionType* exType,
+    void* exPtr
     );
 
 #ifdef __cplusplus

--- a/opencascade-hs/cpp/hs_BRepOffsetAPI_MakePipe.cpp
+++ b/opencascade-hs/cpp/hs_BRepOffsetAPI_MakePipe.cpp
@@ -1,16 +1,34 @@
 #include <BRepOffsetAPI_MakePipe.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepOffsetAPI_MakePipe.h"
 
-BRepOffsetAPI_MakePipe * hs_new_BRepOffsetAPI_MakePipe_fromWireAndShape(TopoDS_Wire * wire, TopoDS_Shape * profile){
-    return new BRepOffsetAPI_MakePipe(*wire, *profile);
+BRepOffsetAPI_MakePipe * hs_new_BRepOffsetAPI_MakePipe_fromWireAndShape(
+        TopoDS_Wire * wire, TopoDS_Shape * profile,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [wire, profile]{
+        return new BRepOffsetAPI_MakePipe(*wire, *profile);
+    });
 }
 
 BRepOffsetAPI_MakePipe * hs_new_BRepOffsetAPI_MakePipe_fromWireShapeTrihedronModeAndForceC1(
     TopoDS_Wire * wire,
     TopoDS_Shape * profile,
-    GeomFill_Trihedron mode, 
-    bool forceApproxC1 ){
-    return new BRepOffsetAPI_MakePipe(*wire, *profile, mode, forceApproxC1);
+    GeomFill_Trihedron mode,
+    bool forceApproxC1,
+    HSExceptionType* exType,
+    void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [wire, profile, mode, forceApproxC1]{
+        return new BRepOffsetAPI_MakePipe(*wire, *profile, mode, forceApproxC1);
+    });
 }
 
 void hs_delete_BRepOffsetAPI_MakePipe(BRepOffsetAPI_MakePipe * builder){

--- a/opencascade-hs/cpp/hs_BRepOffsetAPI_MakePipe.h
+++ b/opencascade-hs/cpp/hs_BRepOffsetAPI_MakePipe.h
@@ -7,13 +7,20 @@
 extern "C" {
 #endif
 
-BRepOffsetAPI_MakePipe * hs_new_BRepOffsetAPI_MakePipe_fromWireAndShape(TopoDS_Wire * wire, TopoDS_Shape * profile);
+BRepOffsetAPI_MakePipe * hs_new_BRepOffsetAPI_MakePipe_fromWireAndShape(
+    TopoDS_Wire * wire, TopoDS_Shape * profile,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 BRepOffsetAPI_MakePipe * hs_new_BRepOffsetAPI_MakePipe_fromWireShapeTrihedronModeAndForceC1(
     TopoDS_Wire * wire,
     TopoDS_Shape * profile,
-    GeomFill_Trihedron mode, 
-    bool forceApproxC1 );
+    GeomFill_Trihedron mode,
+    bool forceApproxC1,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 void hs_delete_BRepOffsetAPI_MakePipe(BRepOffsetAPI_MakePipe * builder);
 

--- a/opencascade-hs/cpp/hs_BRepOffsetAPI_ThruSections.cpp
+++ b/opencascade-hs/cpp/hs_BRepOffsetAPI_ThruSections.cpp
@@ -1,4 +1,5 @@
 #include <BRepOffsetAPI_ThruSections.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepOffsetAPI_ThruSections.h"
 
 BRepOffsetAPI_ThruSections * hs_new_BRepOffsetAPI_ThruSections(bool isSolid, bool ruled, double pres3d){
@@ -9,10 +10,28 @@ void hs_delete_BRepOffsetAPI_ThruSections(BRepOffsetAPI_ThruSections* thruSectio
     delete thruSections;
 }
 
-void hs_BRepOffsetAPI_ThruSections_addWire(BRepOffsetAPI_ThruSections* thruSections, TopoDS_Wire * wire){
-    thruSections->AddWire(*wire);
+void hs_BRepOffsetAPI_ThruSections_addWire(
+        BRepOffsetAPI_ThruSections* thruSections, TopoDS_Wire * wire,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [thruSections, wire]{
+        thruSections->AddWire(*wire);
+    });
 }
 
-void hs_BRepOffsetAPI_ThruSections_addVertex(BRepOffsetAPI_ThruSections* thruSections, TopoDS_Vertex* vertex){
-    thruSections->AddVertex(*vertex);
+void hs_BRepOffsetAPI_ThruSections_addVertex(
+        BRepOffsetAPI_ThruSections* thruSections, TopoDS_Vertex* vertex,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [thruSections, vertex]{
+        thruSections->AddVertex(*vertex);
+    });
 }

--- a/opencascade-hs/cpp/hs_BRepOffsetAPI_ThruSections.h
+++ b/opencascade-hs/cpp/hs_BRepOffsetAPI_ThruSections.h
@@ -12,9 +12,17 @@ BRepOffsetAPI_ThruSections * hs_new_BRepOffsetAPI_ThruSections(bool isSolid, boo
 
 void hs_delete_BRepOffsetAPI_ThruSections(BRepOffsetAPI_ThruSections* thruSections);
 
-void hs_BRepOffsetAPI_ThruSections_addWire(BRepOffsetAPI_ThruSections* thruSections, TopoDS_Wire * wire);
+void hs_BRepOffsetAPI_ThruSections_addWire(
+    BRepOffsetAPI_ThruSections* thruSections, TopoDS_Wire * wire,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-void hs_BRepOffsetAPI_ThruSections_addVertex(BRepOffsetAPI_ThruSections* thruSections, TopoDS_Vertex* vertex);
+void hs_BRepOffsetAPI_ThruSections_addVertex(
+    BRepOffsetAPI_ThruSections* thruSections, TopoDS_Vertex* vertex,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_BRepPrimAPI_MakeBox.cpp
+++ b/opencascade-hs/cpp/hs_BRepPrimAPI_MakeBox.cpp
@@ -1,21 +1,49 @@
 #include <BRepPrimAPI_MakeBox.hxx>
 #include <TopoDS_Solid.hxx>
 #include <TopoDS_Shell.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepPrimAPI_MakeBox.h"
 
 
-BRepPrimAPI_MakeBox * hs_new_BRepPrimAPI_MakeBox_fromPnts(gp_Pnt *a, gp_Pnt *b){
-    return new BRepPrimAPI_MakeBox(*a, *b);
+BRepPrimAPI_MakeBox * hs_new_BRepPrimAPI_MakeBox_fromPnts(
+        gp_Pnt *a, gp_Pnt *b,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [a, b]{
+        return new BRepPrimAPI_MakeBox(*a, *b);
+    });
 }
 
 void hs_delete_BRepPrimAPI_MakeBox(BRepPrimAPI_MakeBox* builder){
     delete builder;
 }
 
-TopoDS_Shape * hs_BRepPrimAPI_MakeBox_Solid(BRepPrimAPI_MakeBox* builder){
-    return new TopoDS_Shape(builder->Solid());
+TopoDS_Shape * hs_BRepPrimAPI_MakeBox_Solid(
+        BRepPrimAPI_MakeBox* builder,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [builder]{
+        return new TopoDS_Shape(builder->Solid());
+    });
 }
 
-TopoDS_Shell * hs_BRepPrimAPI_MakeBox_Shell(BRepPrimAPI_MakeBox* builder){
-    return new TopoDS_Shell(builder->Shell());
+TopoDS_Shell * hs_BRepPrimAPI_MakeBox_Shell(
+        BRepPrimAPI_MakeBox* builder,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [builder]{
+        return new TopoDS_Shell(builder->Shell());
+    });
 }

--- a/opencascade-hs/cpp/hs_BRepPrimAPI_MakeBox.h
+++ b/opencascade-hs/cpp/hs_BRepPrimAPI_MakeBox.h
@@ -7,13 +7,25 @@
 extern "C" {
 #endif
 
-BRepPrimAPI_MakeBox * hs_new_BRepPrimAPI_MakeBox_fromPnts(gp_Pnt * a, gp_Pnt * b);
+BRepPrimAPI_MakeBox * hs_new_BRepPrimAPI_MakeBox_fromPnts(
+    gp_Pnt * a, gp_Pnt * b,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 void hs_delete_BRepPrimAPI_MakeBox(BRepPrimAPI_MakeBox* builder);
 
-TopoDS_Shape * hs_BRepPrimAPI_MakeBox_Solid(BRepPrimAPI_MakeBox* builder);
+TopoDS_Shape * hs_BRepPrimAPI_MakeBox_Solid(
+    BRepPrimAPI_MakeBox* builder,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-TopoDS_Shell * hs_BRepPrimAPI_MakeBox_Shell(BRepPrimAPI_MakeBox* builder);
+TopoDS_Shell * hs_BRepPrimAPI_MakeBox_Shell(
+    BRepPrimAPI_MakeBox* builder,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 
 #ifdef __cplusplus

--- a/opencascade-hs/cpp/hs_BRepPrimAPI_MakeCone.cpp
+++ b/opencascade-hs/cpp/hs_BRepPrimAPI_MakeCone.cpp
@@ -1,7 +1,17 @@
 #include <BRepPrimAPI_MakeCone.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepPrimAPI_MakeCone.h"
 
-TopoDS_Solid * hs_BRepPrimAPI_MakeCone_fromTwoRadiiAndHeight(double r1, double r2, double h){
-    auto builder = BRepPrimAPI_MakeCone(r1, r2, h);
-    return new TopoDS_Solid(builder.Solid());
+TopoDS_Solid * hs_BRepPrimAPI_MakeCone_fromTwoRadiiAndHeight(
+        double r1, double r2, double h,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [r1, r2, h]{
+        auto builder = BRepPrimAPI_MakeCone(r1, r2, h);
+        return new TopoDS_Solid(builder.Solid());
+    });
 }

--- a/opencascade-hs/cpp/hs_BRepPrimAPI_MakeCone.h
+++ b/opencascade-hs/cpp/hs_BRepPrimAPI_MakeCone.h
@@ -7,7 +7,11 @@
 extern "C" {
 #endif
 
-TopoDS_Solid * hs_BRepPrimAPI_MakeCone_fromTwoRadiiAndHeight(double r1, double r2, double h);
+TopoDS_Solid * hs_BRepPrimAPI_MakeCone_fromTwoRadiiAndHeight(
+    double r1, double r2, double h,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_BRepPrimAPI_MakeCylinder.cpp
+++ b/opencascade-hs/cpp/hs_BRepPrimAPI_MakeCylinder.cpp
@@ -1,7 +1,17 @@
 #include <BRepPrimAPI_MakeCylinder.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepPrimAPI_MakeCylinder.h"
 
-TopoDS_Solid * hs_BRepPrimAPI_MakeCylinder_fromRadiusAndHeight(double r, double h){
-    auto builder = BRepPrimAPI_MakeCylinder(r, h);
-    return new TopoDS_Solid(builder.Solid());
+TopoDS_Solid * hs_BRepPrimAPI_MakeCylinder_fromRadiusAndHeight(
+        double r, double h,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [r, h]{
+        auto builder = BRepPrimAPI_MakeCylinder(r, h);
+        return new TopoDS_Solid(builder.Solid());
+    });
 }

--- a/opencascade-hs/cpp/hs_BRepPrimAPI_MakeCylinder.h
+++ b/opencascade-hs/cpp/hs_BRepPrimAPI_MakeCylinder.h
@@ -7,7 +7,11 @@
 extern "C" {
 #endif
 
-TopoDS_Solid * hs_BRepPrimAPI_MakeCylinder_fromRadiusAndHeight(double r, double h);
+TopoDS_Solid * hs_BRepPrimAPI_MakeCylinder_fromRadiusAndHeight(
+    double r, double h,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_BRepPrimAPI_MakePrism.cpp
+++ b/opencascade-hs/cpp/hs_BRepPrimAPI_MakePrism.cpp
@@ -1,13 +1,31 @@
 #include <BRepPrimAPI_MakePrism.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepPrimAPI_MakePrism.h"
 
 
-TopoDS_Shape * hs_BRepPrimAPI_MakePrism_fromVec(TopoDS_Shape * shape, gp_Vec * vec, bool copy, bool canonize){
-    auto builder = BRepPrimAPI_MakePrism(*shape, *vec, copy, canonize);
-    return new TopoDS_Shape(builder.Shape());
+TopoDS_Shape * hs_BRepPrimAPI_MakePrism_fromVec(TopoDS_Shape * shape, gp_Vec * vec, bool copy, bool canonize,
+        HSExceptionType* exType,
+        void** exPtr
+    ){
+        
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [shape, vec, copy, canonize]{
+            auto builder = BRepPrimAPI_MakePrism(*shape, *vec, copy, canonize);
+            return new TopoDS_Shape(builder.Shape());
+    });
 }
 
-TopoDS_Shape * hs_BRepPrimAPI_MakePrism_fromDir(TopoDS_Shape * shape, gp_Dir * dir, bool inf, bool copy, bool canonize){
-    auto builder = BRepPrimAPI_MakePrism(*shape, *dir, inf, copy, canonize);
-    return new TopoDS_Shape(builder.Shape());
+TopoDS_Shape * hs_BRepPrimAPI_MakePrism_fromDir(TopoDS_Shape * shape, gp_Dir * dir, bool inf, bool copy, bool canonize,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [shape, dir, inf, copy, canonize]{
+            auto builder = BRepPrimAPI_MakePrism(*shape, *dir, inf, copy, canonize);
+            return new TopoDS_Shape(builder.Shape());
+    });
 }

--- a/opencascade-hs/cpp/hs_BRepPrimAPI_MakePrism.h
+++ b/opencascade-hs/cpp/hs_BRepPrimAPI_MakePrism.h
@@ -7,9 +7,15 @@
 extern "C" {
 #endif
 
-TopoDS_Shape * hs_BRepPrimAPI_MakePrism_fromVec(TopoDS_Shape * shape, gp_Vec * vec, bool copy, bool canonize);
+TopoDS_Shape * hs_BRepPrimAPI_MakePrism_fromVec(TopoDS_Shape * shape, gp_Vec * vec, bool copy, bool canonize, 
+        HSExceptionType* exType,
+        void** exPtr
+);
 
-TopoDS_Shape * hs_BRepPrimAPI_MakePrism_fromDir(TopoDS_Shape * shape, gp_Dir * dir, bool inf, bool copy, bool canonize);
+TopoDS_Shape * hs_BRepPrimAPI_MakePrism_fromDir(TopoDS_Shape * shape, gp_Dir * dir, bool inf, bool copy, bool canonize, 
+        HSExceptionType* exType,
+        void** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_BRepPrimAPI_MakeRevol.cpp
+++ b/opencascade-hs/cpp/hs_BRepPrimAPI_MakeRevol.cpp
@@ -1,8 +1,18 @@
 #include <BRepPrimAPI_MakeRevol.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepPrimAPI_MakeRevol.h"
 
-BRepPrimAPI_MakeRevol * hs_new_BRepPrimAPI_MakeRevol_fromShapeAndAx1(TopoDS_Shape * shape, gp_Ax1 * axis, bool copy){
-    return new BRepPrimAPI_MakeRevol(*shape, *axis, copy);
+BRepPrimAPI_MakeRevol * hs_new_BRepPrimAPI_MakeRevol_fromShapeAndAx1(
+        TopoDS_Shape * shape, gp_Ax1 * axis, bool copy,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [shape, axis, copy]{
+        return new BRepPrimAPI_MakeRevol(*shape, *axis, copy);
+    });
 }
 
 void hs_delete_BRepPrimAPI_MakeRevol(BRepPrimAPI_MakeRevol * builder){

--- a/opencascade-hs/cpp/hs_BRepPrimAPI_MakeRevol.h
+++ b/opencascade-hs/cpp/hs_BRepPrimAPI_MakeRevol.h
@@ -7,7 +7,11 @@
 extern "C" {
 #endif
 
-BRepPrimAPI_MakeRevol * hs_new_BRepPrimAPI_MakeRevol_fromShapeAndAx1(TopoDS_Shape * shape, gp_Ax1 * axis, bool copy);
+BRepPrimAPI_MakeRevol * hs_new_BRepPrimAPI_MakeRevol_fromShapeAndAx1(
+    TopoDS_Shape * shape, gp_Ax1 * axis, bool copy,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 void hs_delete_BRepPrimAPI_MakeRevol(BRepPrimAPI_MakeRevol * builder);
 

--- a/opencascade-hs/cpp/hs_BRepPrimAPI_MakeSphere.cpp
+++ b/opencascade-hs/cpp/hs_BRepPrimAPI_MakeSphere.cpp
@@ -1,13 +1,32 @@
 #include <BRepPrimAPI_MakeSphere.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepPrimAPI_MakeSphere.h"
 
 
-TopoDS_Solid * hs_BRepPrimAPI_MakeSphere_fromRadius(double r){
-    auto builder = BRepPrimAPI_MakeSphere(r);
-    return new TopoDS_Solid(builder.Solid());
+TopoDS_Solid * hs_BRepPrimAPI_MakeSphere_fromRadius(
+        double r,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [r]{
+        auto builder = BRepPrimAPI_MakeSphere(r);
+        return new TopoDS_Solid(builder.Solid());
+    });
 }
 
-TopoDS_Solid * hs_BRepPrimAPI_MakeSphere_fromPntAndRadius(gp_Pnt * center, double r){
-    auto builder = BRepPrimAPI_MakeSphere(*center, r);
-    return new TopoDS_Solid(builder.Solid());
+TopoDS_Solid * hs_BRepPrimAPI_MakeSphere_fromPntAndRadius(
+        gp_Pnt * center, double r,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [center, r]{
+        auto builder = BRepPrimAPI_MakeSphere(*center, r);
+        return new TopoDS_Solid(builder.Solid());
+    });
 }

--- a/opencascade-hs/cpp/hs_BRepPrimAPI_MakeSphere.h
+++ b/opencascade-hs/cpp/hs_BRepPrimAPI_MakeSphere.h
@@ -7,9 +7,17 @@
 extern "C" {
 #endif
 
-TopoDS_Solid * hs_BRepPrimAPI_MakeSphere_fromRadius(double r);
+TopoDS_Solid * hs_BRepPrimAPI_MakeSphere_fromRadius(
+    double r,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
-TopoDS_Solid * hs_BRepPrimAPI_MakeSphere_fromPntAndRadius(gp_Pnt * center, double r);
+TopoDS_Solid * hs_BRepPrimAPI_MakeSphere_fromPntAndRadius(
+    gp_Pnt * center, double r,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_BRepPrimAPI_MakeTorus.cpp
+++ b/opencascade-hs/cpp/hs_BRepPrimAPI_MakeTorus.cpp
@@ -1,10 +1,20 @@
 #include <BRepPrimAPI_MakeTorus.hxx>
 #include <TopoDS_Solid.hxx>
 #include <TopoDS_Shell.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepPrimAPI_MakeTorus.h"
 
-BRepPrimAPI_MakeTorus * hs_new_BRepPrimAPI_MakeTorus_fromRadii(double major, double minor){
-    return new BRepPrimAPI_MakeTorus(major, minor);
+BRepPrimAPI_MakeTorus * hs_new_BRepPrimAPI_MakeTorus_fromRadii(
+        double major, double minor,
+        HSExceptionType* exType,
+        void** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [major, minor]{
+        return new BRepPrimAPI_MakeTorus(major, minor);
+    });
 }
 
 void hs_delete_BRepPrimAPI_MakeTorus(BRepPrimAPI_MakeTorus * makeTorus){

--- a/opencascade-hs/cpp/hs_BRepPrimAPI_MakeTorus.h
+++ b/opencascade-hs/cpp/hs_BRepPrimAPI_MakeTorus.h
@@ -7,7 +7,11 @@
 extern "C" {
 #endif
 
-BRepPrimAPI_MakeTorus * hs_new_BRepPrimAPI_MakeTorus_fromRadii(double major, double minor);
+BRepPrimAPI_MakeTorus * hs_new_BRepPrimAPI_MakeTorus_fromRadii(
+    double major, double minor,
+    HSExceptionType* exType,
+    void** exPtr
+);
 
 void hs_delete_BRepPrimAPI_MakeTorus(BRepPrimAPI_MakeTorus * makeTorus);
 

--- a/opencascade-hs/cpp/hs_BRepTools_WireExplorer.cpp
+++ b/opencascade-hs/cpp/hs_BRepTools_WireExplorer.cpp
@@ -1,8 +1,18 @@
 #include <BRepTools_WireExplorer.hxx>
+#include "hs_Exception.h"
 #include "hs_BRepTools_WireExplorer.h"
 
-BRepTools_WireExplorer * hs_new_BRepTools_WireExplorer_fromWire(TopoDS_Wire *wire){
-    return new BRepTools_WireExplorer(*wire);
+BRepTools_WireExplorer * hs_new_BRepTools_WireExplorer_fromWire(
+        TopoDS_Wire *wire,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [wire]{
+            return new BRepTools_WireExplorer(*wire);
+        }
+    );
 }
 
 void hs_delete_BRepTools_WireExplorer(BRepTools_WireExplorer * explorer){
@@ -13,12 +23,30 @@ bool hs_BRepTools_WireExplorer_more(BRepTools_WireExplorer * explorer){
     return explorer->More();
 }
 
-void hs_BRepTools_WireExplorer_next(BRepTools_WireExplorer * explorer){
-    explorer->Next();
+void hs_BRepTools_WireExplorer_next(
+        BRepTools_WireExplorer * explorer,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [explorer]{
+            explorer->Next();
+        }
+    );
 }
 
-TopoDS_Edge * hs_BRepTools_WireExplorer_current(BRepTools_WireExplorer * explorer){
-    return (TopoDS_Edge *) &(explorer->Current());
+TopoDS_Edge * hs_BRepTools_WireExplorer_current(
+        BRepTools_WireExplorer * explorer,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [explorer]{
+            return (TopoDS_Edge *) &(explorer->Current());
+        }
+    );
 }
 
 TopAbs_Orientation hs_BRepTools_WireExplorer_orientation(BRepTools_WireExplorer * explorer){

--- a/opencascade-hs/cpp/hs_BRepTools_WireExplorer.h
+++ b/opencascade-hs/cpp/hs_BRepTools_WireExplorer.h
@@ -8,15 +8,24 @@ extern "C" {
 #endif
 
 
-BRepTools_WireExplorer * hs_new_BRepTools_WireExplorer_fromWire(TopoDS_Wire *wire);
+BRepTools_WireExplorer * hs_new_BRepTools_WireExplorer_fromWire(
+    TopoDS_Wire *wire,
+    HSExceptionType* exType, void ** exPtr
+);
 
 void hs_delete_BRepTools_WireExplorer(BRepTools_WireExplorer * explorer);
 
 bool hs_BRepTools_WireExplorer_more(BRepTools_WireExplorer * explorer);
 
-void hs_BRepTools_WireExplorer_next(BRepTools_WireExplorer * explorer);
+void hs_BRepTools_WireExplorer_next(
+    BRepTools_WireExplorer * explorer,
+    HSExceptionType* exType, void ** exPtr
+);
 
-TopoDS_Edge * hs_BRepTools_WireExplorer_current(BRepTools_WireExplorer * explorer);
+TopoDS_Edge * hs_BRepTools_WireExplorer_current(
+    BRepTools_WireExplorer * explorer,
+    HSExceptionType* exType, void ** exPtr
+);
 
 TopAbs_Orientation hs_BRepTools_WireExplorer_orientation(BRepTools_WireExplorer * explorer);
 

--- a/opencascade-hs/cpp/hs_BRep_Tool.cpp
+++ b/opencascade-hs/cpp/hs_BRep_Tool.cpp
@@ -1,30 +1,78 @@
 #include <BRep_Tool.hxx>
 #include <Standard_Handle.hxx>
+#include "hs_Exception.h"
 #include "hs_BRep_Tool.h"
 
-Handle(Geom_Curve) * hs_BRep_Tool_curve(TopoDS_Edge * edge){
-    double s, e;
-    return new Handle(Geom_Curve)(BRep_Tool::Curve(*edge, s, e));
+Handle(Geom_Curve) * hs_BRep_Tool_curve(
+        TopoDS_Edge * edge,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [edge]{
+            double s, e;
+            return new Handle(Geom_Curve)(BRep_Tool::Curve(*edge, s, e));
+        }
+    );
 }
 
-double hs_BRep_Tool_curveParamFirst(TopoDS_Edge * edge){
-    double s, e;
-    BRep_Tool::Curve(*edge, s, e);
-    return s;
+double hs_BRep_Tool_curveParamFirst(
+        TopoDS_Edge * edge,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleExWithDefault(
+        exType,
+        exPtr,
+        [edge]{
+            double s, e;
+            BRep_Tool::Curve(*edge, s, e);
+            return s;
+        },
+        0.0
+    );
 }
 
-double hs_BRep_Tool_curveParamLast(TopoDS_Edge * edge){
-    double s, e;
-    BRep_Tool::Curve(*edge, s, e);
-    return e;
+double hs_BRep_Tool_curveParamLast(
+        TopoDS_Edge * edge,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleExWithDefault(
+        exType,
+        exPtr,
+        [edge]{
+            double s, e;
+            BRep_Tool::Curve(*edge, s, e);
+            return e;
+        },
+        0.0
+    );
 }
 
-gp_Pnt * hs_BRep_Tool_pnt(TopoDS_Vertex * vertex){
-    return new gp_Pnt(BRep_Tool::Pnt(*vertex));
-} 
+gp_Pnt * hs_BRep_Tool_pnt(
+        TopoDS_Vertex * vertex,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [vertex]{
+            return new gp_Pnt(BRep_Tool::Pnt(*vertex));
+        }
+    );
+}
 
-Handle(Poly_Triangulation) * hs_BRep_Tool_triangulation(TopoDS_Face * face, TopLoc_Location * loc){
-    return new opencascade::handle<Poly_Triangulation>(BRep_Tool::Triangulation(*face, *loc));
+Handle(Poly_Triangulation) * hs_BRep_Tool_triangulation(
+        TopoDS_Face * face, TopLoc_Location * loc,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [face, loc]{
+            return new opencascade::handle<Poly_Triangulation>(BRep_Tool::Triangulation(*face, *loc));
+        }
+    );
 }
 
 

--- a/opencascade-hs/cpp/hs_BRep_Tool.h
+++ b/opencascade-hs/cpp/hs_BRep_Tool.h
@@ -7,15 +7,30 @@
 extern "C" {
 #endif
 
-Handle(Geom_Curve) * hs_BRep_Tool_curve(TopoDS_Edge * edge);
+Handle(Geom_Curve) * hs_BRep_Tool_curve(
+    TopoDS_Edge * edge,
+    HSExceptionType* exType, void ** exPtr
+);
 
-double hs_BRep_Tool_curveParamFirst(TopoDS_Edge * edge);
+double hs_BRep_Tool_curveParamFirst(
+    TopoDS_Edge * edge,
+    HSExceptionType* exType, void ** exPtr
+);
 
-double hs_BRep_Tool_curveParamLast(TopoDS_Edge * edge);
+double hs_BRep_Tool_curveParamLast(
+    TopoDS_Edge * edge,
+    HSExceptionType* exType, void ** exPtr
+);
 
-gp_Pnt * hs_BRep_Tool_pnt(TopoDS_Vertex * vertex);
+gp_Pnt * hs_BRep_Tool_pnt(
+    TopoDS_Vertex * vertex,
+    HSExceptionType* exType, void ** exPtr
+);
 
-Handle(Poly_Triangulation) * hs_BRep_Tool_triangulation(TopoDS_Face * face, TopLoc_Location * loc);
+Handle(Poly_Triangulation) * hs_BRep_Tool_triangulation(
+    TopoDS_Face * face, TopLoc_Location * loc,
+    HSExceptionType* exType, void ** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_Bnd_Box.cpp
+++ b/opencascade-hs/cpp/hs_Bnd_Box.cpp
@@ -1,4 +1,5 @@
 #include <Bnd_Box.hxx>
+#include "hs_Exception.h"
 #include "hs_Bnd_Box.h"
 
 Bnd_Box * hs_new_Bnd_Box(){
@@ -9,10 +10,20 @@ void hs_delete_Bnd_Box(Bnd_Box * box){
     delete box;
 }
 
-gp_Pnt * hs_Bnd_Box_cornerMin(Bnd_Box * box){
-    return new gp_Pnt(box->CornerMin());
+gp_Pnt * hs_Bnd_Box_cornerMin(
+        Bnd_Box * box,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(exType, exPtr, [box]{
+        return new gp_Pnt(box->CornerMin());
+    });
 }
 
-gp_Pnt * hs_Bnd_Box_cornerMax(Bnd_Box * box){
-    return new gp_Pnt(box->CornerMax());
+gp_Pnt * hs_Bnd_Box_cornerMax(
+        Bnd_Box * box,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(exType, exPtr, [box]{
+        return new gp_Pnt(box->CornerMax());
+    });
 }

--- a/opencascade-hs/cpp/hs_Bnd_Box.h
+++ b/opencascade-hs/cpp/hs_Bnd_Box.h
@@ -11,9 +11,15 @@ Bnd_Box * hs_new_Bnd_Box();
 
 void hs_delete_Bnd_Box(Bnd_Box * box);
 
-gp_Pnt * hs_Bnd_Box_cornerMin(Bnd_Box * box);
+gp_Pnt * hs_Bnd_Box_cornerMin(
+    Bnd_Box * box,
+    HSExceptionType* exType, void ** exPtr
+);
 
-gp_Pnt * hs_Bnd_Box_cornerMax(Bnd_Box * box);
+gp_Pnt * hs_Bnd_Box_cornerMax(
+    Bnd_Box * box,
+    HSExceptionType* exType, void ** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_Exception.cpp
+++ b/opencascade-hs/cpp/hs_Exception.cpp
@@ -1,0 +1,11 @@
+#include <Standard_Failure.hxx>
+#include "hs_types.h"
+#include "hs_Exception.h"
+
+void hs_delete_std_exception(STD_EXCEPTION * ex){
+    delete ex;
+}
+
+char * hs_std_exception_what(STD_EXCEPTION * ex){
+    return const_cast<char *>(ex->what());
+}

--- a/opencascade-hs/cpp/hs_Exception.cpp
+++ b/opencascade-hs/cpp/hs_Exception.cpp
@@ -2,8 +2,21 @@
 #include "hs_types.h"
 #include "hs_Exception.h"
 
+STD_RUNTIME_ERROR * hs_new_runtime_error(char * msg){
+    return new std::runtime_error(const_cast<const char *>(msg));
+}
+
 void hs_delete_std_exception(STD_EXCEPTION * ex){
     delete ex;
+}
+
+void hs_throw_std_exception(STD_EXCEPTION * ex, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid( 
+        exType,
+        exPtr,
+        [ex]{
+            throw ex;
+        });
 }
 
 char * hs_std_exception_what(STD_EXCEPTION * ex){

--- a/opencascade-hs/cpp/hs_Exception.h
+++ b/opencascade-hs/cpp/hs_Exception.h
@@ -36,6 +36,17 @@ void hs_handleExVoid(HSExceptionType* theType, void ** exPtr, T&& f) {
 
 template <typename T>
 auto hs_handleEx(HSExceptionType* theType, void ** exPtr, T&& f) {
+  return hs_handleExWithDefault(
+    theType, 
+    exPtr, 
+    f,
+    static_cast<decltype(f())>(nullptr)
+  );
+}
+
+
+template <typename T>
+auto hs_handleExWithDefault(HSExceptionType* theType, void ** exPtr, T&& f, decltype(f()) fallback) {
   try {
     *theType = NoException;
     return f();
@@ -52,7 +63,7 @@ auto hs_handleEx(HSExceptionType* theType, void ** exPtr, T&& f) {
   catch(...) {
     *theType = OtherEx;
   }
-  return static_cast<decltype(f())>(nullptr);
+  return fallback;
 }
 
 #endif // __cplusplus

--- a/opencascade-hs/cpp/hs_Exception.h
+++ b/opencascade-hs/cpp/hs_Exception.h
@@ -12,11 +12,11 @@ enum HSExceptionType {
     OtherEx = 3
 };
 
-template <typename T, typename Function, typename ... Args>
-auto hs_handleEx(HSExceptionType* theType, void ** exPtr, T* t, Function f, Args&& ... args) {
+template <typename T>
+void hs_handleExVoid(HSExceptionType* theType, void ** exPtr, T&& f) {
   try {
     *theType = NoException;
-    return (t->*f)(std::forward<Args>(args)...);
+    f();
   }
   catch (Standard_Failure &e) {
     *theType = StandardFailureEx;
@@ -29,6 +29,26 @@ auto hs_handleEx(HSExceptionType* theType, void ** exPtr, T* t, Function f, Args
   catch(...) {
     *theType = OtherEx;
   }
+}
+
+template <typename T>
+auto hs_handleEx(HSExceptionType* theType, void ** exPtr, T&& f) {
+  try {
+    *theType = NoException;
+    return f();
+  }
+  catch (Standard_Failure &e) {
+    *theType = StandardFailureEx;
+    *exPtr = new Standard_Failure(e);
+  }
+  catch (std::exception &e) {
+    *theType = StdExceptionEx;
+    *exPtr = new std::exception(e);
+  }
+  catch(...) {
+    *theType = OtherEx;
+  }
+  return static_cast<decltype(f())>(nullptr);
 }
 
 #endif // __cplusplus

--- a/opencascade-hs/cpp/hs_Exception.h
+++ b/opencascade-hs/cpp/hs_Exception.h
@@ -1,6 +1,8 @@
 #ifndef HS__EXCEPTION__H
 #define HS__EXCEPTION__H
 
+#include "hs_types.h"
+
 #ifdef __cplusplus
 
 enum HSExceptionType {
@@ -30,5 +32,19 @@ auto hs_handleEx(HSExceptionType* theType, void ** exPtr, T* t, Function f, Args
 }
 
 #endif // __cplusplus
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void hs_delete_std_exception(STD_EXCEPTION * ex);
+
+char * hs_std_exception_what(STD_EXCEPTION * ex);
+
+#ifdef __cplusplus
+}
+#endif
+
 
 #endif // HS_EXCEPTION_H

--- a/opencascade-hs/cpp/hs_Exception.h
+++ b/opencascade-hs/cpp/hs_Exception.h
@@ -5,6 +5,8 @@
 
 #ifdef __cplusplus
 
+#include <stdexcept>
+
 enum HSExceptionType {
     NoException = 0,
     StandardFailureEx = 1,
@@ -24,7 +26,8 @@ void hs_handleExVoid(HSExceptionType* theType, void ** exPtr, T&& f) {
   }
   catch (std::exception &e) {
     *theType = StdExceptionEx;
-    *exPtr = new std::exception(e);
+    std::exception* copy = new std::runtime_error(e.what());
+    *exPtr = copy;
   }
   catch(...) {
     *theType = OtherEx;
@@ -43,7 +46,8 @@ auto hs_handleEx(HSExceptionType* theType, void ** exPtr, T&& f) {
   }
   catch (std::exception &e) {
     *theType = StdExceptionEx;
-    *exPtr = new std::exception(e);
+    std::exception* copy = new std::runtime_error(e.what());
+    *exPtr = copy;
   }
   catch(...) {
     *theType = OtherEx;

--- a/opencascade-hs/cpp/hs_Exception.h
+++ b/opencascade-hs/cpp/hs_Exception.h
@@ -6,6 +6,7 @@
 #ifdef __cplusplus
 
 #include <stdexcept>
+#include <Standard_Failure.hxx>
 
 enum HSExceptionType {
     NoException = 0,

--- a/opencascade-hs/cpp/hs_Exception.h
+++ b/opencascade-hs/cpp/hs_Exception.h
@@ -30,6 +30,11 @@ void hs_handleExVoid(HSExceptionType* theType, void ** exPtr, T&& f) {
     std::exception* copy = new std::runtime_error(e.what());
     *exPtr = copy;
   }
+  catch (std::exception *e) {
+    *theType = StdExceptionEx;
+    std::exception* copy = new std::runtime_error(e->what());
+    *exPtr = copy;
+  }
   catch(...) {
     *theType = OtherEx;
   }
@@ -48,6 +53,11 @@ auto hs_handleExWithDefault(HSExceptionType* theType, void ** exPtr, T&& f, decl
   catch (std::exception &e) {
     *theType = StdExceptionEx;
     std::exception* copy = new std::runtime_error(e.what());
+    *exPtr = copy;
+  }
+  catch (std::exception *e) {
+    *theType = StdExceptionEx;
+    std::exception* copy = new std::runtime_error(e->what());
     *exPtr = copy;
   }
   catch(...) {
@@ -73,9 +83,13 @@ auto hs_handleEx(HSExceptionType* theType, void ** exPtr, T&& f) {
 extern "C" {
 #endif
 
+STD_RUNTIME_ERROR * hs_new_runtime_error(char * msg);
+
 void hs_delete_std_exception(STD_EXCEPTION * ex);
 
 char * hs_std_exception_what(STD_EXCEPTION * ex);
+
+void hs_throw_std_exception(STD_EXCEPTION * ex, HSExceptionType* exType, void ** exPtr);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_Exception.h
+++ b/opencascade-hs/cpp/hs_Exception.h
@@ -1,0 +1,34 @@
+#ifndef HS__EXCEPTION__H
+#define HS__EXCEPTION__H
+
+#ifdef __cplusplus
+
+enum HSExceptionType {
+    NoException = 0,
+    StandardFailureEx = 1,
+    StdExceptionEx = 2,
+    OtherEx = 3
+};
+
+template <typename T, typename Function, typename ... Args>
+auto hs_handleEx(HSExceptionType* theType, void ** exPtr, T* t, Function f, Args&& ... args) {
+  try {
+    *theType = NoException;
+    return (t->*f)(std::forward<Args>(args)...);
+  }
+  catch (Standard_Failure &e) {
+    *theType = StandardFailureEx;
+    *exPtr = new Standard_Failure(e);
+  }
+  catch (std::exception &e) {
+    *theType = StdExceptionEx;
+    *exPtr = new std::exception(e);
+  }
+  catch(...) {
+    *theType = OtherEx;
+  }
+}
+
+#endif // __cplusplus
+
+#endif // HS_EXCEPTION_H

--- a/opencascade-hs/cpp/hs_Exception.h
+++ b/opencascade-hs/cpp/hs_Exception.h
@@ -35,17 +35,6 @@ void hs_handleExVoid(HSExceptionType* theType, void ** exPtr, T&& f) {
 }
 
 template <typename T>
-auto hs_handleEx(HSExceptionType* theType, void ** exPtr, T&& f) {
-  return hs_handleExWithDefault(
-    theType, 
-    exPtr, 
-    f,
-    static_cast<decltype(f())>(nullptr)
-  );
-}
-
-
-template <typename T>
 auto hs_handleExWithDefault(HSExceptionType* theType, void ** exPtr, T&& f, decltype(f()) fallback) {
   try {
     *theType = NoException;
@@ -64,6 +53,16 @@ auto hs_handleExWithDefault(HSExceptionType* theType, void ** exPtr, T&& f, decl
     *theType = OtherEx;
   }
   return fallback;
+}
+
+template <typename T>
+auto hs_handleEx(HSExceptionType* theType, void ** exPtr, T&& f) {
+  return hs_handleExWithDefault(
+    theType, 
+    exPtr, 
+    f,
+    static_cast<decltype(f())>(nullptr)
+  );
 }
 
 #endif // __cplusplus

--- a/opencascade-hs/cpp/hs_Font_BRepFont.cpp
+++ b/opencascade-hs/cpp/hs_Font_BRepFont.cpp
@@ -1,4 +1,5 @@
 #include <Font_BRepFont.hxx>
+#include "hs_Exception.h"
 #include "hs_Font_BRepFont.h"
 
 
@@ -6,20 +7,49 @@ Font_BRepFont * hs_new_Font_BRepFont(){
     return new Font_BRepFont();
 }
 
-Font_BRepFont * hs_new_Font_BRepFont_fromStringAndSize(char * path, double size){
-    return new Font_BRepFont(path, size);
+Font_BRepFont * hs_new_Font_BRepFont_fromStringAndSize(
+        char * path, double size,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [path, size]{
+            return new Font_BRepFont(path, size);
+        }
+    );
 }
 
 void hs_delete_Font_BRepFont(Font_BRepFont * font){
     delete font;
 }
 
-bool hs_Font_BRepFont_initPathAndSize(Font_BRepFont * font, char * path, double size){
-    return font->Init(path, size, 0);
+bool hs_Font_BRepFont_initPathAndSize(
+        Font_BRepFont * font, char * path, double size,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleExWithDefault(
+        exType,
+        exPtr,
+        [font, path, size]{
+            return font->Init(path, size, 0);
+        },
+        false
+    );
 }
 
-bool hs_Font_BRepFont_initNameAspectAndSize(Font_BRepFont * font, char * name, Font_FontAspect aspect, double size){
-    return font->Init(name, aspect, size);
+bool hs_Font_BRepFont_initNameAspectAndSize(
+        Font_BRepFont * font, char * name, Font_FontAspect aspect, double size,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleExWithDefault(
+        exType,
+        exPtr,
+        [font, name, aspect, size]{
+            return font->Init(name, aspect, size);
+        },
+        false
+    );
 }
 
 double hs_Font_BRepFont_ascender(Font_BRepFont * font){

--- a/opencascade-hs/cpp/hs_Font_BRepFont.h
+++ b/opencascade-hs/cpp/hs_Font_BRepFont.h
@@ -9,11 +9,20 @@ extern "C" {
 
 Font_BRepFont * hs_new_Font_BRepFont();
 
-Font_BRepFont * hs_new_Font_BRepFont_fromStringAndSize(char * path, double size);
+Font_BRepFont * hs_new_Font_BRepFont_fromStringAndSize(
+    char * path, double size,
+    HSExceptionType* exType, void ** exPtr
+);
 
-bool hs_Font_BRepFont_initPathAndSize(Font_BRepFont * font, char * path, double size);
+bool hs_Font_BRepFont_initPathAndSize(
+    Font_BRepFont * font, char * path, double size,
+    HSExceptionType* exType, void ** exPtr
+);
 
-bool hs_Font_BRepFont_initNameAspectAndSize(Font_BRepFont * font, char * name, Font_FontAspect aspect, double size);
+bool hs_Font_BRepFont_initNameAspectAndSize(
+    Font_BRepFont * font, char * name, Font_FontAspect aspect, double size,
+    HSExceptionType* exType, void ** exPtr
+);
 
 void hs_delete_Font_BRepFont(Font_BRepFont * font);
 

--- a/opencascade-hs/cpp/hs_Font_BRepTextBuilder.cpp
+++ b/opencascade-hs/cpp/hs_Font_BRepTextBuilder.cpp
@@ -1,4 +1,5 @@
 #include <Font_BRepTextBuilder.hxx>
+#include "hs_Exception.h"
 #include "hs_Font_BRepTextBuilder.h"
 
 Font_BRepTextBuilder * hs_new_Font_BRepTextBuilder(){
@@ -10,12 +11,19 @@ void hs_delete_Font_BRepTextBuilder(Font_BRepTextBuilder * builder){
 }
 
 TopoDS_Shape * hs_Font_BRepTextBuilder_perform(
-        Font_BRepTextBuilder * builder, 
+        Font_BRepTextBuilder * builder,
         Font_BRepFont * font,
-        char * theString, 
+        char * theString,
         gp_Ax3 * thePenLoc,
         Graphic3d_HorizontalTextAlignment theHAlign,
-        Graphic3d_VerticalTextAlignment theVAlign
+        Graphic3d_VerticalTextAlignment theVAlign,
+        HSExceptionType* exType, void ** exPtr
     ) {
-    return new TopoDS_Shape (builder ->Perform(*font, theString, *thePenLoc, theHAlign, theVAlign));
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [builder, font, theString, thePenLoc, theHAlign, theVAlign]{
+            return new TopoDS_Shape (builder ->Perform(*font, theString, *thePenLoc, theHAlign, theVAlign));
+        }
+    );
 }

--- a/opencascade-hs/cpp/hs_Font_BRepTextBuilder.h
+++ b/opencascade-hs/cpp/hs_Font_BRepTextBuilder.h
@@ -12,12 +12,13 @@ Font_BRepTextBuilder * hs_new_Font_BRepTextBuilder();
 void hs_delete_Font_BRepTextBuilder(Font_BRepTextBuilder * builder);
 
 TopoDS_Shape * hs_Font_BRepTextBuilder_perform(
-        Font_BRepTextBuilder * builder, 
+        Font_BRepTextBuilder * builder,
         Font_BRepFont * font,
-        char * theString, 
+        char * theString,
         gp_Ax3 * thePenLoc,
         Graphic3d_HorizontalTextAlignment theHAlign,
-        Graphic3d_VerticalTextAlignment theVAlign
+        Graphic3d_VerticalTextAlignment theVAlign,
+        HSExceptionType* exType, void ** exPtr
     );
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_GCPnts_AbscissaPoint.cpp
+++ b/opencascade-hs/cpp/hs_GCPnts_AbscissaPoint.cpp
@@ -1,17 +1,37 @@
 #include <GCPnts_AbscissaPoint.hxx>
 #include <BRepAdaptor_Curve.hxx>
+#include "hs_Exception.h"
 #include "hs_GCPnts_AbscissaPoint.h"
 
-GCPnts_AbscissaPoint * hs_new_GCPnts_AbscissaPoint(BRepAdaptor_Curve * curve, double abscissa, double u0){
-    return new GCPnts_AbscissaPoint(*curve, abscissa, u0);
+GCPnts_AbscissaPoint * hs_new_GCPnts_AbscissaPoint(
+        BRepAdaptor_Curve * curve, double abscissa, double u0,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [curve, abscissa, u0]{
+            return new GCPnts_AbscissaPoint(*curve, abscissa, u0);
+        }
+    );
 }
 
 void hs_delete_GCPnts_AbscissaPoint(GCPnts_AbscissaPoint * abscissaPoint){
     delete abscissaPoint;
 }
 
-double hs_GCPnts_AbscissaPoint_parameter(GCPnts_AbscissaPoint * abscissaPoint){
-    return abscissaPoint->Parameter();
+double hs_GCPnts_AbscissaPoint_parameter(
+        GCPnts_AbscissaPoint * abscissaPoint,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleExWithDefault(
+        exType,
+        exPtr,
+        [abscissaPoint]{
+            return abscissaPoint->Parameter();
+        },
+        0.0
+    );
 }
 
 bool hs_GCPnts_AbscissaPoint_isDone(GCPnts_AbscissaPoint * abscissaPoint){

--- a/opencascade-hs/cpp/hs_GCPnts_AbscissaPoint.h
+++ b/opencascade-hs/cpp/hs_GCPnts_AbscissaPoint.h
@@ -7,11 +7,17 @@
 extern "C" {
 #endif
 
-GCPnts_AbscissaPoint * hs_new_GCPnts_AbscissaPoint(BRepAdaptor_Curve * curve, double abscissa, double u0);
+GCPnts_AbscissaPoint * hs_new_GCPnts_AbscissaPoint(
+    BRepAdaptor_Curve * curve, double abscissa, double u0,
+    HSExceptionType* exType, void ** exPtr
+);
 
 void hs_delete_GCPnts_AbscissaPoint(GCPnts_AbscissaPoint * abscissaPoint);
 
-double hs_GCPnts_AbscissaPoint_parameter(GCPnts_AbscissaPoint * abscissaPoint);
+double hs_GCPnts_AbscissaPoint_parameter(
+    GCPnts_AbscissaPoint * abscissaPoint,
+    HSExceptionType* exType, void ** exPtr
+);
 
 bool hs_GCPnts_AbscissaPoint_isDone(GCPnts_AbscissaPoint * abscissaPoint);
 

--- a/opencascade-hs/cpp/hs_GC_MakeArcOfCircle.cpp
+++ b/opencascade-hs/cpp/hs_GC_MakeArcOfCircle.cpp
@@ -1,11 +1,31 @@
 #include <GC_MakeArcOfCircle.hxx>
+#include <Standard_Failure.hxx>
+#include "hs_Exception.h"
 #include "hs_GC_MakeArcOfCircle.h"
 
-Handle(Geom_TrimmedCurve) * hs_GC_MakeArcOfCircle_from3Pnts(gp_Pnt * a, gp_Pnt * b, gp_Pnt * c){
-    return new opencascade::handle(GC_MakeArcOfCircle(*a, *b, *c).Value());
+Handle(Geom_TrimmedCurve) * hs_GC_MakeArcOfCircle_from3Pnts(
+        gp_Pnt * a, gp_Pnt * b, gp_Pnt * c,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [a, b, c]{
+            return new opencascade::handle(GC_MakeArcOfCircle(*a, *b, *c).Value());
+        }
+    );
 }
 
-Handle(Geom_TrimmedCurve) * hs_GC_MakeArcOfCircle_fromPntsAndVec(gp_Pnt * a, gp_Vec * b, gp_Pnt * c){
-    return new opencascade::handle(GC_MakeArcOfCircle(*a, *b, *c).Value());
+Handle(Geom_TrimmedCurve) * hs_GC_MakeArcOfCircle_fromPntsAndVec(
+        gp_Pnt * a, gp_Vec * b, gp_Pnt * c,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [a, b, c]{
+            return new opencascade::handle(GC_MakeArcOfCircle(*a, *b, *c).Value());
+        }
+    );
 }
 

--- a/opencascade-hs/cpp/hs_GC_MakeArcOfCircle.h
+++ b/opencascade-hs/cpp/hs_GC_MakeArcOfCircle.h
@@ -7,9 +7,15 @@
 extern "C" {
 #endif
 
-Handle(Geom_TrimmedCurve) * hs_GC_MakeArcOfCircle_from3Pnts(gp_Pnt * a, gp_Pnt * b, gp_Pnt * c);
+Handle(Geom_TrimmedCurve) * hs_GC_MakeArcOfCircle_from3Pnts(
+    gp_Pnt * a, gp_Pnt * b, gp_Pnt * c,
+    HSExceptionType* exType, void ** exPtr
+);
 
-Handle(Geom_TrimmedCurve) * hs_GC_MakeArcOfCircle_fromPntsAndVec(gp_Pnt * a, gp_Vec * b, gp_Pnt * c);
+Handle(Geom_TrimmedCurve) * hs_GC_MakeArcOfCircle_fromPntsAndVec(
+    gp_Pnt * a, gp_Vec * b, gp_Pnt * c,
+    HSExceptionType* exType, void ** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_GC_MakeSegment.cpp
+++ b/opencascade-hs/cpp/hs_GC_MakeSegment.cpp
@@ -1,6 +1,17 @@
 #include <GC_MakeSegment.hxx>
+#include <Standard_Failure.hxx>
+#include "hs_Exception.h"
 #include "hs_GC_MakeSegment.h"
 
-Handle(Geom_TrimmedCurve) * hs_GC_MakeSegment_fromPnts(gp_Pnt* a, gp_Pnt* b){
-    return new opencascade::handle(GC_MakeSegment(*a, *b).Value());
+Handle(Geom_TrimmedCurve) * hs_GC_MakeSegment_fromPnts(
+        gp_Pnt* a, gp_Pnt* b,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [a, b]{
+            return new opencascade::handle(GC_MakeSegment(*a, *b).Value());
+        }
+    );
 }

--- a/opencascade-hs/cpp/hs_GC_MakeSegment.h
+++ b/opencascade-hs/cpp/hs_GC_MakeSegment.h
@@ -7,7 +7,10 @@
 extern "C" {
 #endif
 
-Handle(Geom_TrimmedCurve) * hs_GC_MakeSegment_fromPnts(gp_Pnt* a, gp_Pnt* b);
+Handle(Geom_TrimmedCurve) * hs_GC_MakeSegment_fromPnts(
+    gp_Pnt* a, gp_Pnt* b,
+    HSExceptionType* exType, void ** exPtr
+);
 
 
 #ifdef __cplusplus

--- a/opencascade-hs/cpp/hs_GProp_GProps.cpp
+++ b/opencascade-hs/cpp/hs_GProp_GProps.cpp
@@ -1,26 +1,51 @@
 #include <GProp_GProps.hxx>
+#include "hs_Exception.h"
 #include "hs_GProp_GProps.h"
 
-GProp_GProps * hs_new_GProp_GProps(){
-    return new GProp_GProps();
+GProp_GProps * hs_new_GProp_GProps(
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(exType, exPtr, []{
+        return new GProp_GProps();
+    });
 }
 
-GProp_GProps * hs_new_GProp_GProps_fromSystemLocation(gp_Pnt * pnt){
-    return new GProp_GProps(*pnt);
+GProp_GProps * hs_new_GProp_GProps_fromSystemLocation(
+        gp_Pnt * pnt,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(exType, exPtr, [pnt]{
+        return new GProp_GProps(*pnt);
+    });
 }
 
 void  hs_delete_GProp_GProps(GProp_GProps * props){
     delete props;
 }
 
-double hs_GProp_GProps_mass(GProp_GProps * props){
-    return props->Mass();
+double hs_GProp_GProps_mass(
+        GProp_GProps * props,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleExWithDefault(exType, exPtr, [props]{
+        return props->Mass();
+    }, 0.0);
 }
 
-gp_Pnt * hs_GProp_GProps_centreOfMass(GProp_GProps * props){
-    return new gp_Pnt(props->CentreOfMass());
+gp_Pnt * hs_GProp_GProps_centreOfMass(
+        GProp_GProps * props,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(exType, exPtr, [props]{
+        return new gp_Pnt(props->CentreOfMass());
+    });
 }
 
-double hs_GProp_GProps_momentOfInertia(GProp_GProps * props, gp_Ax1 * ax){
-    return props->MomentOfInertia(*ax);
+double hs_GProp_GProps_momentOfInertia(
+        GProp_GProps * props, gp_Ax1 * ax,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleExWithDefault(exType, exPtr, [props, ax]{
+        return props->MomentOfInertia(*ax);
+    }, 0.0);
 }

--- a/opencascade-hs/cpp/hs_GProp_GProps.h
+++ b/opencascade-hs/cpp/hs_GProp_GProps.h
@@ -7,17 +7,31 @@
 extern "C" {
 #endif
 
-GProp_GProps * hs_new_GProp_GProps();
+GProp_GProps * hs_new_GProp_GProps(
+    HSExceptionType* exType, void ** exPtr
+);
 
-GProp_GProps * hs_new_GProp_GProps_fromSystemLocation(gp_Pnt * pnt);
+GProp_GProps * hs_new_GProp_GProps_fromSystemLocation(
+    gp_Pnt * pnt,
+    HSExceptionType* exType, void ** exPtr
+);
 
 void  hs_delete_GProp_GProps(GProp_GProps * props);
 
-double hs_GProp_GProps_mass(GProp_GProps * props);
+double hs_GProp_GProps_mass(
+    GProp_GProps * props,
+    HSExceptionType* exType, void ** exPtr
+);
 
-gp_Pnt * hs_GProp_GProps_centreOfMass(GProp_GProps * props);
+gp_Pnt * hs_GProp_GProps_centreOfMass(
+    GProp_GProps * props,
+    HSExceptionType* exType, void ** exPtr
+);
 
-double hs_GProp_GProps_momentOfInertia(GProp_GProps * props, gp_Ax1 * ax);
+double hs_GProp_GProps_momentOfInertia(
+    GProp_GProps * props, gp_Ax1 * ax,
+    HSExceptionType* exType, void ** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_GeomAdaptor_Curve.cpp
+++ b/opencascade-hs/cpp/hs_GeomAdaptor_Curve.cpp
@@ -1,8 +1,18 @@
 #include <GeomAdaptor_Curve.hxx>
+#include "hs_Exception.h"
 #include "hs_GeomAdaptor_Curve.h"
 
-GeomAdaptor_Curve * hs_new_GeomAdaptor_Curve_fromHandle(Handle(Geom_Curve) *curve){
-    return new GeomAdaptor_Curve(*curve);
+GeomAdaptor_Curve * hs_new_GeomAdaptor_Curve_fromHandle(
+        Handle(Geom_Curve) *curve,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [curve]{
+            return new GeomAdaptor_Curve(*curve);
+        }
+    );
 }
 
 void hs_delete_GeomAdaptor_Curve(GeomAdaptor_Curve * adaptor){
@@ -17,6 +27,15 @@ double hs_GeomAdaptor_Curve_lastParameter(GeomAdaptor_Curve * adaptor){
     return adaptor->LastParameter();
 }
 
-Handle(Geom_Curve)* hs_GeomAdaptor_Curve_curve(GeomAdaptor_Curve * adaptor){
-    return new opencascade::handle(adaptor->Curve());
+Handle(Geom_Curve)* hs_GeomAdaptor_Curve_curve(
+        GeomAdaptor_Curve * adaptor,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [adaptor]{
+            return new opencascade::handle(adaptor->Curve());
+        }
+    );
 }

--- a/opencascade-hs/cpp/hs_GeomAdaptor_Curve.h
+++ b/opencascade-hs/cpp/hs_GeomAdaptor_Curve.h
@@ -7,7 +7,10 @@
 extern "C" {
 #endif
 
-GeomAdaptor_Curve * hs_new_GeomAdaptor_Curve_fromHandle(Handle(Geom_Curve) *curve);
+GeomAdaptor_Curve * hs_new_GeomAdaptor_Curve_fromHandle(
+    Handle(Geom_Curve) *curve,
+    HSExceptionType* exType, void ** exPtr
+);
 
 void hs_delete_GeomAdaptor_Curve(GeomAdaptor_Curve * adaptor);
 
@@ -15,7 +18,10 @@ double hs_GeomAdaptor_Curve_firstParameter(GeomAdaptor_Curve * adaptor);
 
 double hs_GeomAdaptor_Curve_lastParameter(GeomAdaptor_Curve * adaptor);
 
-Handle(Geom_Curve)* hs_GeomAdaptor_Curve_curve(GeomAdaptor_Curve * adaptor);
+Handle(Geom_Curve)* hs_GeomAdaptor_Curve_curve(
+    GeomAdaptor_Curve * adaptor,
+    HSExceptionType* exType, void ** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_GeomConvert_ApproxCurve.cpp
+++ b/opencascade-hs/cpp/hs_GeomConvert_ApproxCurve.cpp
@@ -1,23 +1,40 @@
 #include <GeomConvert_ApproxCurve.hxx>
 #include <Geom_Curve.hxx>
+#include "hs_Exception.h"
 #include "hs_GeomConvert_ApproxCurve.h"
 
 GeomConvert_ApproxCurve * hs_new_GeomConvert_ApproxCurve_fromCurveToleranceOrderSegmentsAndDegree(
-        Handle(Geom_Curve) *curve, 
-        double tolerance, 
-        GeomAbs_Shape order, 
-        int maxSegments, 
-        int maxDegree
+        Handle(Geom_Curve) *curve,
+        double tolerance,
+        GeomAbs_Shape order,
+        int maxSegments,
+        int maxDegree,
+        HSExceptionType* exType, void ** exPtr
     ) {
-        return new GeomConvert_ApproxCurve(*curve, tolerance, order, maxSegments, maxDegree);
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [curve, tolerance, order, maxSegments, maxDegree]{
+            return new GeomConvert_ApproxCurve(*curve, tolerance, order, maxSegments, maxDegree);
+        }
+    );
 }
 
 void hs_delete_GeomConvert_ApproxCurve(GeomConvert_ApproxCurve * approxCurve){
     delete approxCurve;
 }
 
-Handle(Geom_BSplineCurve) * hs_GeomConvert_ApproxCurve_curve(GeomConvert_ApproxCurve * approxCurve){
-    return new opencascade::handle(approxCurve->Curve());
+Handle(Geom_BSplineCurve) * hs_GeomConvert_ApproxCurve_curve(
+        GeomConvert_ApproxCurve * approxCurve,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [approxCurve]{
+            return new opencascade::handle(approxCurve->Curve());
+        }
+    );
 }
 
 bool hs_GeomConvert_ApproxCurve_isDone(GeomConvert_ApproxCurve * approxCurve){

--- a/opencascade-hs/cpp/hs_GeomConvert_ApproxCurve.h
+++ b/opencascade-hs/cpp/hs_GeomConvert_ApproxCurve.h
@@ -8,16 +8,20 @@ extern "C" {
 #endif
 
 GeomConvert_ApproxCurve * hs_new_GeomConvert_ApproxCurve_fromCurveToleranceOrderSegmentsAndDegree(
-        Handle(Geom_Curve) *curve, 
-        double tolerance, 
-        GeomAbs_Shape order, 
-        int maxSegments, 
-        int maxDegree
+        Handle(Geom_Curve) *curve,
+        double tolerance,
+        GeomAbs_Shape order,
+        int maxSegments,
+        int maxDegree,
+        HSExceptionType* exType, void ** exPtr
     );
 
 void hs_delete_GeomConvert_ApproxCurve(GeomConvert_ApproxCurve * approxCurve);
 
-Handle(Geom_BSplineCurve) * hs_GeomConvert_ApproxCurve_curve(GeomConvert_ApproxCurve * approxCurve);
+Handle(Geom_BSplineCurve) * hs_GeomConvert_ApproxCurve_curve(
+    GeomConvert_ApproxCurve * approxCurve,
+    HSExceptionType* exType, void ** exPtr
+);
 
 bool hs_GeomConvert_ApproxCurve_isDone(GeomConvert_ApproxCurve * approxCurve);
 

--- a/opencascade-hs/cpp/hs_GeomConvert_BSplineCurveToBezierCurve.cpp
+++ b/opencascade-hs/cpp/hs_GeomConvert_BSplineCurveToBezierCurve.cpp
@@ -1,17 +1,35 @@
 #include <GeomConvert_BSplineCurveToBezierCurve.hxx>
 #include "hs_types.h"
+#include "hs_Exception.h"
 #include "hs_GeomConvert_BSplineCurveToBezierCurve.h"
 
-GeomConvert_BSplineCurveToBezierCurve * hs_new_GeomConvert_BSplineCurveToBezierCurve_fromHandle (Handle(Geom_BSplineCurve) *basisCurve){
-    return new GeomConvert_BSplineCurveToBezierCurve(*basisCurve);
+GeomConvert_BSplineCurveToBezierCurve * hs_new_GeomConvert_BSplineCurveToBezierCurve_fromHandle (
+        Handle(Geom_BSplineCurve) *basisCurve,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [basisCurve]{
+            return new GeomConvert_BSplineCurveToBezierCurve(*basisCurve);
+        }
+    );
 }
 
 GeomConvert_BSplineCurveToBezierCurve * hs_new_GeomConvert_BSplineCurveToBezierCurve_fromHandleParametersAndTolerance (
     Handle(Geom_BSplineCurve) *basisCurve,
-    double firstParameter, 
+    double firstParameter,
     double secondParameter,
-    double tolerance ){
-    return new GeomConvert_BSplineCurveToBezierCurve(*basisCurve, firstParameter, secondParameter, tolerance);
+    double tolerance,
+    HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [basisCurve, firstParameter, secondParameter, tolerance]{
+            return new GeomConvert_BSplineCurveToBezierCurve(*basisCurve, firstParameter, secondParameter, tolerance);
+        }
+    );
 }
 
 void hs_delete_GeomConvert_BSplineCurveToBezierCurve(GeomConvert_BSplineCurveToBezierCurve* ptr){
@@ -22,6 +40,15 @@ int hs_GeomConvert_BSplineCurveToBezierCurve_nbArcs(GeomConvert_BSplineCurveToBe
     return ptr->NbArcs();
 }
 
-Handle(Geom_BezierCurve) * hs_GeomConvert_BSplineCurveToBezierCurve_arc(GeomConvert_BSplineCurveToBezierCurve * ptr, int n){
-    return new opencascade::handle(ptr->Arc(n));
-} 
+Handle(Geom_BezierCurve) * hs_GeomConvert_BSplineCurveToBezierCurve_arc(
+        GeomConvert_BSplineCurveToBezierCurve * ptr, int n,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [ptr, n]{
+            return new opencascade::handle(ptr->Arc(n));
+        }
+    );
+}

--- a/opencascade-hs/cpp/hs_GeomConvert_BSplineCurveToBezierCurve.h
+++ b/opencascade-hs/cpp/hs_GeomConvert_BSplineCurveToBezierCurve.h
@@ -7,19 +7,27 @@
 extern "C" {
 #endif
 
-GeomConvert_BSplineCurveToBezierCurve * hs_new_GeomConvert_BSplineCurveToBezierCurve_fromHandle (Handle(Geom_BSplineCurve) *basisCurve);
+GeomConvert_BSplineCurveToBezierCurve * hs_new_GeomConvert_BSplineCurveToBezierCurve_fromHandle (
+    Handle(Geom_BSplineCurve) *basisCurve,
+    HSExceptionType* exType, void ** exPtr
+);
 
 GeomConvert_BSplineCurveToBezierCurve * hs_new_GeomConvert_BSplineCurveToBezierCurve_fromHandleParametersAndTolerance (
     Handle(Geom_BSplineCurve) *basisCurve,
-    double firstParameter, 
+    double firstParameter,
     double secondParameter,
-    double tolerance );
+    double tolerance,
+    HSExceptionType* exType, void ** exPtr
+);
 
 void hs_delete_GeomConvert_BSplineCurveToBezierCurve(GeomConvert_BSplineCurveToBezierCurve* ptr);
 
 int hs_GeomConvert_BSplineCurveToBezierCurve_nbArcs(GeomConvert_BSplineCurveToBezierCurve* ptr);
 
-Handle(Geom_BezierCurve) * hs_GeomConvert_BSplineCurveToBezierCurve_arc(GeomConvert_BSplineCurveToBezierCurve * ptr, int n);
+Handle(Geom_BezierCurve) * hs_GeomConvert_BSplineCurveToBezierCurve_arc(
+    GeomConvert_BSplineCurveToBezierCurve * ptr, int n,
+    HSExceptionType* exType, void ** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_Geom_BSplineCurve.cpp
+++ b/opencascade-hs/cpp/hs_Geom_BSplineCurve.cpp
@@ -2,6 +2,7 @@
 #include <NCollection_Array1.hxx>
 #include <gp_Pnt.hxx>
 #include <Standard_Handle.hxx>
+#include "hs_Exception.h"
 #include "hs_Geom_BSplineCurve.h"
 
 Handle(Geom_BSplineCurve) * hs_Geom_BSplineCurve_toHandle(Geom_BSplineCurve * curve){
@@ -20,14 +21,32 @@ int hs_Geom_BSplineCurve_nbPoles(Handle(Geom_BSplineCurve)* h){
     return (*h)->NbPoles();
 }
 
-gp_Pnt * hs_Geom_BSplineCurve_pole(Handle(Geom_BSplineCurve)* h, int index){
-    return new gp_Pnt((*h)->Pole(index));
+gp_Pnt * hs_Geom_BSplineCurve_pole(
+        Handle(Geom_BSplineCurve)* h, int index,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [h, index]{
+            return new gp_Pnt((*h)->Pole(index));
+        }
+    );
 }
 
 bool hs_Geom_BSplineCurve_isRational(Handle(Geom_BSplineCurve) *h) {
     return (*h)->IsRational();
 }
 
-void hs_Geom_BSplineCurve_segment(Handle(Geom_BSplineCurve) *h, double u1, double u2, double confusion){
-    (*h)->Segment(u1, u2, confusion);
+void hs_Geom_BSplineCurve_segment(
+        Handle(Geom_BSplineCurve) *h, double u1, double u2, double confusion,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [h, u1, u2, confusion]{
+            (*h)->Segment(u1, u2, confusion);
+        }
+    );
 }

--- a/opencascade-hs/cpp/hs_Geom_BSplineCurve.h
+++ b/opencascade-hs/cpp/hs_Geom_BSplineCurve.h
@@ -16,11 +16,17 @@ void hs_delete_Geom_BSplineCurve(Geom_BSplineCurve * curve);
 
 int hs_Geom_BSplineCurve_nbPoles(Handle(Geom_BSplineCurve)* h);
 
-gp_Pnt * hs_Geom_BSplineCurve_pole(Handle(Geom_BSplineCurve)* h, int index);
+gp_Pnt * hs_Geom_BSplineCurve_pole(
+    Handle(Geom_BSplineCurve)* h, int index,
+    HSExceptionType* exType, void ** exPtr
+);
 
 bool hs_Geom_BSplineCurve_isRational(Handle(Geom_BSplineCurve) *h);
 
-void hs_Geom_BSplineCurve_segment(Handle(Geom_BSplineCurve) *h, double u1, double u2, double confusion);
+void hs_Geom_BSplineCurve_segment(
+    Handle(Geom_BSplineCurve) *h, double u1, double u2, double confusion,
+    HSExceptionType* exType, void ** exPtr
+);
 
 
 #ifdef __cplusplus

--- a/opencascade-hs/cpp/hs_Geom_BezierCurve.cpp
+++ b/opencascade-hs/cpp/hs_Geom_BezierCurve.cpp
@@ -2,10 +2,20 @@
 #include <NCollection_Array1.hxx>
 #include <gp_Pnt.hxx>
 #include <Standard_Handle.hxx>
+#include "hs_Exception.h"
 #include "hs_Geom_BezierCurve.h"
 
-Geom_BezierCurve * hs_new_Geom_BezierCurve_fromPnts(ARRAY_1(gp_Pnt) * pnts){
-    return new Geom_BezierCurve(*pnts);
+Geom_BezierCurve * hs_new_Geom_BezierCurve_fromPnts(
+        ARRAY_1(gp_Pnt) * pnts,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [pnts]{
+            return new Geom_BezierCurve(*pnts);
+        }
+    );
 }
 
 Handle(Geom_BezierCurve) * hs_Geom_BezierCurve_toHandle(Geom_BezierCurve * curve){
@@ -16,8 +26,17 @@ int hs_Geom_BezierCurve_nbPoles(Handle(Geom_BezierCurve)* h){
     return (*h)->NbPoles();
 }
 
-gp_Pnt * hs_Geom_BezierCurve_pole(Handle(Geom_BezierCurve)* h, int index){
-    return new gp_Pnt((*h)->Pole(index));
+gp_Pnt * hs_Geom_BezierCurve_pole(
+        Handle(Geom_BezierCurve)* h, int index,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [h, index]{
+            return new gp_Pnt((*h)->Pole(index));
+        }
+    );
 }
 
 bool hs_Geom_BezierCurve_isRational(Handle(Geom_BezierCurve) *h) {
@@ -32,6 +51,15 @@ void hs_delete_Geom_BezierCurve(Geom_BezierCurve * curve){
     delete curve;
 }
 
-void hs_Geom_BezierCurve_segment(Handle(Geom_BezierCurve) *h, double u1, double u2){
-    (*h)->Segment(u1, u2);
+void hs_Geom_BezierCurve_segment(
+        Handle(Geom_BezierCurve) *h, double u1, double u2,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [h, u1, u2]{
+            (*h)->Segment(u1, u2);
+        }
+    );
 }

--- a/opencascade-hs/cpp/hs_Geom_BezierCurve.h
+++ b/opencascade-hs/cpp/hs_Geom_BezierCurve.h
@@ -7,13 +7,19 @@
 extern "C" {
 #endif
 
-Geom_BezierCurve * hs_new_Geom_BezierCurve_fromPnts(ARRAY_1(gp_Pnt) * pnts);
+Geom_BezierCurve * hs_new_Geom_BezierCurve_fromPnts(
+    ARRAY_1(gp_Pnt) * pnts,
+    HSExceptionType* exType, void ** exPtr
+);
 
 Handle(Geom_BezierCurve) * hs_Geom_BezierCurve_toHandle(Geom_BezierCurve * curve);
 
 int hs_Geom_BezierCurve_nbPoles(Handle(Geom_BezierCurve)* h);
 
-gp_Pnt * hs_Geom_BezierCurve_pole(Handle(Geom_BezierCurve)* h, int index);
+gp_Pnt * hs_Geom_BezierCurve_pole(
+    Handle(Geom_BezierCurve)* h, int index,
+    HSExceptionType* exType, void ** exPtr
+);
 
 bool hs_Geom_BezierCurve_isRational(Handle(Geom_BezierCurve) *h);
 
@@ -21,7 +27,10 @@ void hs_delete_Handle_Geom_BezierCurve(Handle(Geom_BezierCurve)* h);
 
 void hs_delete_Geom_BezierCurve(Geom_BezierCurve * curve);
 
-void hs_Geom_BezierCurve_segment(Handle(Geom_BezierCurve) *h, double u1, double u2);
+void hs_Geom_BezierCurve_segment(
+    Handle(Geom_BezierCurve) *h, double u1, double u2,
+    HSExceptionType* exType, void ** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_Geom_Curve.cpp
+++ b/opencascade-hs/cpp/hs_Geom_Curve.cpp
@@ -2,14 +2,24 @@
 #include <GeomAbs_CurveType.hxx>
 #include <gp_Pnt.hxx>
 #include <gp_Vec.hxx>
+#include "hs_Exception.h"
 #include "hs_Geom_Curve.h"
 
 void hs_delete_Handle_Geom_Curve(Handle(Geom_Curve) * handle){
     delete handle;
 }
 
-gp_Pnt * hs_Geom_Curve_value(Handle(Geom_Curve) * curve, double u){
-    return new gp_Pnt((*curve)->Value(u));
+gp_Pnt * hs_Geom_Curve_value(
+        Handle(Geom_Curve) * curve, double u,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [curve, u]{
+            return new gp_Pnt((*curve)->Value(u));
+        }
+    );
 }
 
 double hs_Geom_Curve_firstParameter(Handle(Geom_Curve) * curve){
@@ -20,14 +30,42 @@ double hs_Geom_Curve_lastParameter(Handle(Geom_Curve) * curve){
     return (*curve)->LastParameter();
 }
 
-gp_Vec * hs_Geom_Curve_dn(Handle (Geom_Curve) * curve, double u, int n){
-    return new gp_Vec((*curve)->DN(u, n));
+gp_Vec * hs_Geom_Curve_dn(
+        Handle (Geom_Curve) * curve, double u, int n,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [curve, u, n]{
+            return new gp_Vec((*curve)->DN(u, n));
+        }
+    );
 }
 
-double hs_Geom_Curve_reversedParameter(Handle (Geom_Curve) * curve, double parameter){
-    return (*curve)->ReversedParameter(parameter);
+double hs_Geom_Curve_reversedParameter(
+        Handle (Geom_Curve) * curve, double parameter,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleExWithDefault(
+        exType,
+        exPtr,
+        [curve, parameter]{
+            return (*curve)->ReversedParameter(parameter);
+        },
+        0.0
+    );
 }
 
-Handle (Geom_Curve) * hs_Geom_Curve_reversed(Handle (Geom_Curve) * curve){
-    return new opencascade::handle<Geom_Curve>((*curve)->Reversed());
+Handle (Geom_Curve) * hs_Geom_Curve_reversed(
+        Handle (Geom_Curve) * curve,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [curve]{
+            return new opencascade::handle<Geom_Curve>((*curve)->Reversed());
+        }
+    );
 }

--- a/opencascade-hs/cpp/hs_Geom_Curve.h
+++ b/opencascade-hs/cpp/hs_Geom_Curve.h
@@ -8,17 +8,29 @@ extern "C" {
 #endif
 void hs_delete_Handle_Geom_Curve(Handle(Geom_Curve) * handle);
 
-gp_Pnt * hs_Geom_Curve_value(Handle(Geom_Curve) * curve, double u);
+gp_Pnt * hs_Geom_Curve_value(
+    Handle(Geom_Curve) * curve, double u,
+    HSExceptionType* exType, void ** exPtr
+);
 
 double hs_Geom_Curve_firstParameter(Handle(Geom_Curve) * curve);
 
 double hs_Geom_Curve_lastParameter(Handle(Geom_Curve) * curve);
 
-gp_Vec * hs_Geom_Curve_dn(Handle (Geom_Curve) * curve, double u, int n);
+gp_Vec * hs_Geom_Curve_dn(
+    Handle (Geom_Curve) * curve, double u, int n,
+    HSExceptionType* exType, void ** exPtr
+);
 
-double hs_Geom_Curve_reversedParameter(Handle (Geom_Curve) * curve, double parameter);
+double hs_Geom_Curve_reversedParameter(
+    Handle (Geom_Curve) * curve, double parameter,
+    HSExceptionType* exType, void ** exPtr
+);
 
-Handle (Geom_Curve) * hs_Geom_Curve_reversed(Handle (Geom_Curve) * curve);
+Handle (Geom_Curve) * hs_Geom_Curve_reversed(
+    Handle (Geom_Curve) * curve,
+    HSExceptionType* exType, void ** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_HLRBRep_Algo.cpp
+++ b/opencascade-hs/cpp/hs_HLRBRep_Algo.cpp
@@ -1,4 +1,5 @@
 #include <HLRBRep_Algo.hxx>
+#include "hs_Exception.h"
 #include "hs_HLRBRep_Algo.h"
 #include <Standard_Handle.hxx>
 
@@ -14,14 +15,41 @@ void hs_HLRBRep_Algo_projector(Handle(HLRBRep_Algo) * algo, HLRAlgo_Projector * 
     (*algo)->Projector(*projector);
 }
 
-void hs_HLRBRep_Algo_update(Handle(HLRBRep_Algo) * algo){
-    (*algo)->Update();
+void hs_HLRBRep_Algo_update(
+        Handle(HLRBRep_Algo) * algo,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [algo]{
+            (*algo)->Update();
+        }
+    );
 }
 
-void hs_HLRBRep_Algo_hide(Handle(HLRBRep_Algo) * algo){
-    (*algo)->Hide();
+void hs_HLRBRep_Algo_hide(
+        Handle(HLRBRep_Algo) * algo,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [algo]{
+            (*algo)->Hide();
+        }
+    );
 }
 
-void hs_HLRBRep_Algo_add(Handle(HLRBRep_Algo) * algo, TopoDS_Shape * shape){
-    (*algo)->Add(*shape);
+void hs_HLRBRep_Algo_add(
+        Handle(HLRBRep_Algo) * algo, TopoDS_Shape * shape,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [algo, shape]{
+            (*algo)->Add(*shape);
+        }
+    );
 }

--- a/opencascade-hs/cpp/hs_HLRBRep_Algo.h
+++ b/opencascade-hs/cpp/hs_HLRBRep_Algo.h
@@ -13,11 +13,20 @@ void hs_delete_HLRBRep_Algo(Handle(HLRBRep_Algo) * algo);
 
 void hs_HLRBRep_Algo_projector(Handle(HLRBRep_Algo) * algo, HLRAlgo_Projector * projector);
 
-void hs_HLRBRep_Algo_update(Handle(HLRBRep_Algo) * algo);
+void hs_HLRBRep_Algo_update(
+    Handle(HLRBRep_Algo) * algo,
+    HSExceptionType* exType, void ** exPtr
+);
 
-void hs_HLRBRep_Algo_hide(Handle(HLRBRep_Algo) * algo);
+void hs_HLRBRep_Algo_hide(
+    Handle(HLRBRep_Algo) * algo,
+    HSExceptionType* exType, void ** exPtr
+);
 
-void hs_HLRBRep_Algo_add(Handle(HLRBRep_Algo) * algo, TopoDS_Shape * shape);
+void hs_HLRBRep_Algo_add(
+    Handle(HLRBRep_Algo) * algo, TopoDS_Shape * shape,
+    HSExceptionType* exType, void ** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_HLRBRep_HLRToShape.cpp
+++ b/opencascade-hs/cpp/hs_HLRBRep_HLRToShape.cpp
@@ -1,14 +1,33 @@
 #include <HLRBRep_HLRToShape.hxx>
+#include "hs_Exception.h"
 #include "hs_HLRBRep_HLRToShape.h"
 
-HLRBRep_HLRToShape * hs_new_HLRBRep_HLRToShape_fromHandleAlgo(Handle(HLRBRep_Algo) * algo){
-    return new HLRBRep_HLRToShape(*algo);
+HLRBRep_HLRToShape * hs_new_HLRBRep_HLRToShape_fromHandleAlgo(
+        Handle(HLRBRep_Algo) * algo,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [algo]{
+            return new HLRBRep_HLRToShape(*algo);
+        }
+    );
 }
 
 void hs_delete_HLRBRep_HLRToShape(HLRBRep_HLRToShape *hlrToShape){
     delete hlrToShape;
 }
 
-TopoDS_Shape * hs_HLRBRep_HLRToShape_compoundOfEdges(HLRBRep_HLRToShape * toShape, HLRBRep_TypeOfResultingEdge edgeType, bool visible, bool in3d){
-    return new TopoDS_Shape(toShape->CompoundOfEdges(edgeType, visible, in3d));
+TopoDS_Shape * hs_HLRBRep_HLRToShape_compoundOfEdges(
+        HLRBRep_HLRToShape * toShape, HLRBRep_TypeOfResultingEdge edgeType, bool visible, bool in3d,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [toShape, edgeType, visible, in3d]{
+            return new TopoDS_Shape(toShape->CompoundOfEdges(edgeType, visible, in3d));
+        }
+    );
 }

--- a/opencascade-hs/cpp/hs_HLRBRep_HLRToShape.h
+++ b/opencascade-hs/cpp/hs_HLRBRep_HLRToShape.h
@@ -7,11 +7,17 @@
 extern "C" {
 #endif
 
-HLRBRep_HLRToShape * hs_new_HLRBRep_HLRToShape_fromHandleAlgo(Handle(HLRBRep_Algo) * algo);
+HLRBRep_HLRToShape * hs_new_HLRBRep_HLRToShape_fromHandleAlgo(
+    Handle(HLRBRep_Algo) * algo,
+    HSExceptionType* exType, void ** exPtr
+);
 
 void hs_delete_HLRBRep_HLRToShape(HLRBRep_HLRToShape *hlrToShape);
 
-TopoDS_Shape * hs_HLRBRep_HLRToShape_compoundOfEdges(HLRBRep_HLRToShape * toShape, HLRBRep_TypeOfResultingEdge edgeType, bool visible, bool in3d);
+TopoDS_Shape * hs_HLRBRep_HLRToShape_compoundOfEdges(
+    HLRBRep_HLRToShape * toShape, HLRBRep_TypeOfResultingEdge edgeType, bool visible, bool in3d,
+    HSExceptionType* exType, void ** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_NCollection_Array1.cpp
+++ b/opencascade-hs/cpp/hs_NCollection_Array1.cpp
@@ -1,13 +1,24 @@
 #include <NCollection_Array1.hxx>
 #include <gp_Pnt.hxx>
+#include "hs_Exception.h"
 #include "hs_NCollection_Array1.h"
 
-ARRAY_1(gp_Pnt) * hs_new_NCollection_Array1_gp_Pnt(int lower, int upper){
-    return new NCollection_Array1<gp_Pnt>(lower, upper);
+ARRAY_1(gp_Pnt) * hs_new_NCollection_Array1_gp_Pnt(
+        int lower, int upper,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(exType, exPtr, [lower, upper]{
+        return new NCollection_Array1<gp_Pnt>(lower, upper);
+    });
 }
 
-void hs_NCollection_Array1_gp_Pnt_setValue(ARRAY_1(gp_Pnt) * arr, int index, gp_Pnt * value){
-    arr->SetValue(index, *value);
+void hs_NCollection_Array1_gp_Pnt_setValue(
+        ARRAY_1(gp_Pnt) * arr, int index, gp_Pnt * value,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(exType, exPtr, [arr, index, value]{
+        arr->SetValue(index, *value);
+    });
 }
 
 void hs_delete_NCollection_Array1_gp_Pnt(ARRAY_1(gp_Pnt) * arr){

--- a/opencascade-hs/cpp/hs_NCollection_Array1.h
+++ b/opencascade-hs/cpp/hs_NCollection_Array1.h
@@ -7,9 +7,15 @@
 extern "C" {
 #endif
 
-ARRAY_1(gp_Pnt) * hs_new_NCollection_Array1_gp_Pnt(int lower, int upper);
+ARRAY_1(gp_Pnt) * hs_new_NCollection_Array1_gp_Pnt(
+    int lower, int upper,
+    HSExceptionType* exType, void ** exPtr
+);
 
-void hs_NCollection_Array1_gp_Pnt_setValue(ARRAY_1(gp_Pnt) * arr, int index, gp_Pnt * value);
+void hs_NCollection_Array1_gp_Pnt_setValue(
+    ARRAY_1(gp_Pnt) * arr, int index, gp_Pnt * value,
+    HSExceptionType* exType, void ** exPtr
+);
 
 void hs_delete_NCollection_Array1_gp_Pnt(ARRAY_1(gp_Pnt) * arr);
 

--- a/opencascade-hs/cpp/hs_Poly_Triangle.cpp
+++ b/opencascade-hs/cpp/hs_Poly_Triangle.cpp
@@ -1,4 +1,5 @@
 #include <Poly_Triangle.hxx>
+#include "hs_Exception.h"
 #include "hs_Poly_Triangle.h"
 
 Poly_Triangle * hs_new_Poly_Triangle_fromIndices(int n1, int n2, int n3){
@@ -9,10 +10,29 @@ void hs_delete_Poly_Triangle(Poly_Triangle * triangle){
     delete triangle;
 }
 
-int hs_Poly_Triangle_value(Poly_Triangle * triangle, int index){
-    return triangle->Value(index);
+int hs_Poly_Triangle_value(
+        Poly_Triangle * triangle, int index,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleExWithDefault(
+        exType,
+        exPtr,
+        [triangle, index]{
+            return triangle->Value(index);
+        },
+        0
+    );
 }
 
-void hs_Poly_Triangle_setValue(Poly_Triangle * triangle, int index, int node){
-    triangle->Set(index, node);
+void hs_Poly_Triangle_setValue(
+        Poly_Triangle * triangle, int index, int node,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [triangle, index, node]{
+            triangle->Set(index, node);
+        }
+    );
 }

--- a/opencascade-hs/cpp/hs_Poly_Triangle.h
+++ b/opencascade-hs/cpp/hs_Poly_Triangle.h
@@ -11,9 +11,15 @@ Poly_Triangle * hs_new_Poly_Triangle_fromIndices(int n1, int n2, int n3);
 
 void hs_delete_Poly_Triangle(Poly_Triangle * triangle);
 
-int hs_Poly_Triangle_value(Poly_Triangle * triangle, int index);
+int hs_Poly_Triangle_value(
+    Poly_Triangle * triangle, int index,
+    HSExceptionType* exType, void ** exPtr
+);
 
-void hs_Poly_Triangle_setValue(Poly_Triangle * triangle, int index, int node);
+void hs_Poly_Triangle_setValue(
+    Poly_Triangle * triangle, int index, int node,
+    HSExceptionType* exType, void ** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_Poly_Triangulation.cpp
+++ b/opencascade-hs/cpp/hs_Poly_Triangulation.cpp
@@ -1,8 +1,18 @@
 #include <Poly_Triangulation.hxx>
+#include "hs_Exception.h"
 #include "hs_Poly_Triangulation.h"
 
-Handle(Poly_Triangulation) * hs_new_Poly_Triangulation(int nbNodes, int nbTriangles, bool hasUVNodes, bool hasNormals){
-    return new opencascade::handle<Poly_Triangulation>(new Poly_Triangulation(nbNodes, nbTriangles, hasUVNodes, hasNormals));
+Handle(Poly_Triangulation) * hs_new_Poly_Triangulation(
+        int nbNodes, int nbTriangles, bool hasUVNodes, bool hasNormals,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [nbNodes, nbTriangles, hasUVNodes, hasNormals]{
+            return new opencascade::handle<Poly_Triangulation>(new Poly_Triangulation(nbNodes, nbTriangles, hasUVNodes, hasNormals));
+        }
+    );
 }
 
 void hs_delete_Poly_Triangulation(Handle(Poly_Triangulation) * triangulation){
@@ -18,18 +28,54 @@ int hs_Poly_Triangulation_nbTriangles(Handle(Poly_Triangulation) * triangulation
 }
 
 
-gp_Pnt * hs_Poly_Triangulation_node(Handle(Poly_Triangulation) * triangulation, int index){
-    return new gp_Pnt(triangulation->get()->Node(index));
+gp_Pnt * hs_Poly_Triangulation_node(
+        Handle(Poly_Triangulation) * triangulation, int index,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [triangulation, index]{
+            return new gp_Pnt(triangulation->get()->Node(index));
+        }
+    );
 }
 
-void hs_Poly_Triangulation_setNode(Handle(Poly_Triangulation) * triangulation, int index, gp_Pnt * pnt){
-    triangulation->get()->SetNode(index, *pnt);
+void hs_Poly_Triangulation_setNode(
+        Handle(Poly_Triangulation) * triangulation, int index, gp_Pnt * pnt,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [triangulation, index, pnt]{
+            triangulation->get()->SetNode(index, *pnt);
+        }
+    );
 }
 
-Poly_Triangle * hs_Poly_Triangulation_triangle(Handle(Poly_Triangulation) * triangulation, int index){
-    return new Poly_Triangle(triangulation->get()->Triangle(index));
+Poly_Triangle * hs_Poly_Triangulation_triangle(
+        Handle(Poly_Triangulation) * triangulation, int index,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [triangulation, index]{
+            return new Poly_Triangle(triangulation->get()->Triangle(index));
+        }
+    );
 }
 
-void hs_Poly_Triangulation_setTriangle(Handle(Poly_Triangulation) * triangulation, int index, Poly_Triangle * triangle){
-    triangulation->get()->SetTriangle(index, *triangle);
+void hs_Poly_Triangulation_setTriangle(
+        Handle(Poly_Triangulation) * triangulation, int index, Poly_Triangle * triangle,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [triangulation, index, triangle]{
+            triangulation->get()->SetTriangle(index, *triangle);
+        }
+    );
 }

--- a/opencascade-hs/cpp/hs_Poly_Triangulation.h
+++ b/opencascade-hs/cpp/hs_Poly_Triangulation.h
@@ -7,7 +7,10 @@
 extern "C" {
 #endif
 
-Handle(Poly_Triangulation) * hs_new_Poly_Triangulation(int nbNodes, int nbTriangles, bool hasUVNodes, bool hasNormals);
+Handle(Poly_Triangulation) * hs_new_Poly_Triangulation(
+    int nbNodes, int nbTriangles, bool hasUVNodes, bool hasNormals,
+    HSExceptionType* exType, void ** exPtr
+);
 
 void hs_delete_Poly_Triangulation(Handle(Poly_Triangulation) * triangulation);
 
@@ -15,13 +18,25 @@ int hs_Poly_Triangulation_nbNodes(Handle(Poly_Triangulation) * triangulation);
 
 int hs_Poly_Triangulation_nbTriangles(Handle(Poly_Triangulation) * triangulation);
 
-gp_Pnt * hs_Poly_Triangulation_node(Handle(Poly_Triangulation) * triangulation, int index);
+gp_Pnt * hs_Poly_Triangulation_node(
+    Handle(Poly_Triangulation) * triangulation, int index,
+    HSExceptionType* exType, void ** exPtr
+);
 
-void hs_Poly_Triangulation_setNode(Handle(Poly_Triangulation) * triangulation, int index, gp_Pnt * pnt);
+void hs_Poly_Triangulation_setNode(
+    Handle(Poly_Triangulation) * triangulation, int index, gp_Pnt * pnt,
+    HSExceptionType* exType, void ** exPtr
+);
 
-Poly_Triangle * hs_Poly_Triangulation_triangle(Handle(Poly_Triangulation) * triangulation, int index);
+Poly_Triangle * hs_Poly_Triangulation_triangle(
+    Handle(Poly_Triangulation) * triangulation, int index,
+    HSExceptionType* exType, void ** exPtr
+);
 
-void hs_Poly_Triangulation_setTriangle(Handle(Poly_Triangulation) * triangulation, int index, Poly_Triangle * triangle);
+void hs_Poly_Triangulation_setTriangle(
+    Handle(Poly_Triangulation) * triangulation, int index, Poly_Triangle * triangle,
+    HSExceptionType* exType, void ** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_RWGltf_CafWriter.cpp
+++ b/opencascade-hs/cpp/hs_RWGltf_CafWriter.cpp
@@ -1,4 +1,5 @@
 #include <RWGltf_CafWriter.hxx>
+#include "hs_Exception.h"
 #include "hs_RWGltf_CafWriter.h"
 
 RWGltf_CafWriter * hs_new_RWGltf_CafWriter(char * theFile, bool isBinary){
@@ -9,6 +10,15 @@ void hs_delete_RWGltf_CafWriter(RWGltf_CafWriter * theWriter){
     delete theWriter;   
 }
 
-void hs_RWGltf_CafWriter_Perform(RWGltf_CafWriter * theWriter, Handle(TDocStd_Document) * theDocument, TColStd_IndexedDataMapOfStringString * theFileInfo, Message_ProgressRange * theProgress){
-    theWriter->Perform(*theDocument, *theFileInfo, *theProgress);
+void hs_RWGltf_CafWriter_Perform(
+    RWGltf_CafWriter * theWriter, Handle(TDocStd_Document) * theDocument, TColStd_IndexedDataMapOfStringString * theFileInfo, Message_ProgressRange * theProgress,
+    HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [theWriter, theDocument, theFileInfo, theProgress]{
+            theWriter->Perform(*theDocument, *theFileInfo, *theProgress);
+        }
+    );
 }

--- a/opencascade-hs/cpp/hs_RWGltf_CafWriter.h
+++ b/opencascade-hs/cpp/hs_RWGltf_CafWriter.h
@@ -11,7 +11,10 @@ RWGltf_CafWriter * hs_new_RWGltf_CafWriter(char * theFile, bool isBinary);
 
 void hs_delete_RWGltf_CafWriter(RWGltf_CafWriter * theWriter);
 
-void hs_RWGltf_CafWriter_Perform(RWGltf_CafWriter * theWriter, Handle(TDocStd_Document) * theDocument, TColStd_IndexedDataMapOfStringString * theFileInfo, Message_ProgressRange * theProgress);
+void hs_RWGltf_CafWriter_Perform(
+    RWGltf_CafWriter * theWriter, Handle(TDocStd_Document) * theDocument, TColStd_IndexedDataMapOfStringString * theFileInfo, Message_ProgressRange * theProgress,
+    HSExceptionType* exType, void ** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_RWMesh_CafReader.cpp
+++ b/opencascade-hs/cpp/hs_RWMesh_CafReader.cpp
@@ -1,4 +1,5 @@
 #include <RWMesh_CafReader.hxx>
+#include "hs_Exception.h"
 #include "hs_RWMesh_CafReader.h"
 
 void hs_RWMesh_CafReader_setDocument(RWMesh_CafReader * reader, Handle(TDocStd_Document) * document){
@@ -9,10 +10,29 @@ void hs_RWMesh_CafReader_setFileLengthUnit(RWMesh_CafReader * reader, double sca
     reader->SetFileLengthUnit(scale);
 }
 
-TopoDS_Shape * hs_RWMesh_CafReader_singleShape(RWMesh_CafReader * reader){
-    return new TopoDS_Shape(reader->SingleShape());
+TopoDS_Shape * hs_RWMesh_CafReader_singleShape(
+    RWMesh_CafReader * reader,
+    HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [reader]{
+            return new TopoDS_Shape(reader->SingleShape());
+        }
+    );
 }
 
-bool hs_RWMesh_CafReader_perform(RWMesh_CafReader * reader, char * filename, Message_ProgressRange * progress){
-    return reader->Perform(filename, *progress);
+bool hs_RWMesh_CafReader_perform(
+    RWMesh_CafReader * reader, char * filename, Message_ProgressRange * progress,
+    HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleExWithDefault(
+        exType,
+        exPtr,
+        [reader, filename, progress]{
+            return reader->Perform(filename, *progress);
+        },
+        false
+    );
 }

--- a/opencascade-hs/cpp/hs_RWMesh_CafReader.h
+++ b/opencascade-hs/cpp/hs_RWMesh_CafReader.h
@@ -11,9 +11,15 @@ void hs_RWMesh_CafReader_setDocument(RWMesh_CafReader * reader, Handle(TDocStd_D
 
 void hs_RWMesh_CafReader_setFileLengthUnit(RWMesh_CafReader * reader, double scale);
 
-TopoDS_Shape * hs_RWMesh_CafReader_singleShape(RWMesh_CafReader * reader);
+TopoDS_Shape * hs_RWMesh_CafReader_singleShape(
+    RWMesh_CafReader * reader,
+    HSExceptionType* exType, void ** exPtr
+);
 
-bool hs_RWMesh_CafReader_perform(RWMesh_CafReader * reader, char * filename, Message_ProgressRange * progress);
+bool hs_RWMesh_CafReader_perform(
+    RWMesh_CafReader * reader, char * filename, Message_ProgressRange * progress,
+    HSExceptionType* exType, void ** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_RWObj_CafWriter.cpp
+++ b/opencascade-hs/cpp/hs_RWObj_CafWriter.cpp
@@ -1,4 +1,5 @@
 #include <RWObj_CafWriter.hxx>
+#include "hs_Exception.h"
 #include "hs_RWObj_CafWriter.h"
 
 RWObj_CafWriter * hs_new_RWObj_CafWriter(char * filename){
@@ -9,6 +10,15 @@ void hs_delete_RWObj_CafWriter(RWObj_CafWriter * writer){
     delete writer;
 }
 
-void hs_RWObj_CafWriter_Perform(RWObj_CafWriter * theWriter, Handle(TDocStd_Document) * theDocument, TColStd_IndexedDataMapOfStringString * theFileInfo, Message_ProgressRange * theProgress){
-    theWriter->Perform(*theDocument, *theFileInfo, *theProgress);
+void hs_RWObj_CafWriter_Perform(
+    RWObj_CafWriter * theWriter, Handle(TDocStd_Document) * theDocument, TColStd_IndexedDataMapOfStringString * theFileInfo, Message_ProgressRange * theProgress,
+    HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [theWriter, theDocument, theFileInfo, theProgress]{
+            theWriter->Perform(*theDocument, *theFileInfo, *theProgress);
+        }
+    );
 }

--- a/opencascade-hs/cpp/hs_RWObj_CafWriter.h
+++ b/opencascade-hs/cpp/hs_RWObj_CafWriter.h
@@ -11,7 +11,10 @@ RWObj_CafWriter * hs_new_RWObj_CafWriter(char * theFile);
 
 void hs_delete_RWObj_CafWriter(RWObj_CafWriter * theWriter);
 
-void hs_RWObj_CafWriter_Perform(RWObj_CafWriter * theWriter, Handle(TDocStd_Document) * theDocument, TColStd_IndexedDataMapOfStringString * theFileInfo, Message_ProgressRange * theProgress);
+void hs_RWObj_CafWriter_Perform(
+    RWObj_CafWriter * theWriter, Handle(TDocStd_Document) * theDocument, TColStd_IndexedDataMapOfStringString * theFileInfo, Message_ProgressRange * theProgress,
+    HSExceptionType* exType, void ** exPtr
+);
 
 #ifdef __cplusplus
     }

--- a/opencascade-hs/cpp/hs_STEPControl_Writer.cpp
+++ b/opencascade-hs/cpp/hs_STEPControl_Writer.cpp
@@ -1,4 +1,5 @@
 #include <STEPControl_Writer.hxx>
+#include "hs_Exception.h"
 #include "hs_STEPControl_Writer.h"
 
 STEPControl_Writer * hs_new_STEPControl_Writer(){
@@ -17,10 +18,30 @@ void hs_STEPControl_Writer_unsetTolerance(STEPControl_Writer * writer){
     writer->UnsetTolerance();
 }
 
-IFSelect_ReturnStatus hs_STEPControl_Writer_transfer(STEPControl_Writer * writer, TopoDS_Shape * shape, STEPControl_StepModelType mode, bool compgraph){
-    return writer->Transfer(*shape, mode, compgraph);
+IFSelect_ReturnStatus hs_STEPControl_Writer_transfer(
+    STEPControl_Writer * writer, TopoDS_Shape * shape, STEPControl_StepModelType mode, bool compgraph,
+    HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleExWithDefault(
+        exType,
+        exPtr,
+        [writer, shape, mode, compgraph]{
+            return writer->Transfer(*shape, mode, compgraph);
+        },
+        IFSelect_RetError
+    );
 }
 
-IFSelect_ReturnStatus hs_STEPControl_Writer_write(STEPControl_Writer* writer, char* filename){
-    return writer->Write(filename);
+IFSelect_ReturnStatus hs_STEPControl_Writer_write(
+    STEPControl_Writer* writer, char* filename,
+    HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleExWithDefault(
+        exType,
+        exPtr,
+        [writer, filename]{
+            return writer->Write(filename);
+        },
+        IFSelect_RetError
+    );
 }

--- a/opencascade-hs/cpp/hs_STEPControl_Writer.h
+++ b/opencascade-hs/cpp/hs_STEPControl_Writer.h
@@ -15,9 +15,15 @@ void hs_STEPControl_Writer_setTolerance(STEPControl_Writer * writer, double tole
 
 void hs_STEPControl_Writer_unsetTolerance(STEPControl_Writer * writer);
 
-IFSelect_ReturnStatus hs_STEPControl_Writer_transfer(STEPControl_Writer * writer, TopoDS_Shape * shape, STEPControl_StepModelType mode, bool compgraph);
+IFSelect_ReturnStatus hs_STEPControl_Writer_transfer(
+    STEPControl_Writer * writer, TopoDS_Shape * shape, STEPControl_StepModelType mode, bool compgraph,
+    HSExceptionType* exType, void ** exPtr
+);
 
-IFSelect_ReturnStatus hs_STEPControl_Writer_write(STEPControl_Writer* writer, char* filename);
+IFSelect_ReturnStatus hs_STEPControl_Writer_write(
+    STEPControl_Writer* writer, char* filename,
+    HSExceptionType* exType, void ** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_ShapeConstruct_Curve.cpp
+++ b/opencascade-hs/cpp/hs_ShapeConstruct_Curve.cpp
@@ -1,5 +1,6 @@
 #include <ShapeConstruct_Curve.hxx>
 #include <Geom_Curve.hxx>
+#include "hs_Exception.h"
 #include "hs_ShapeConstruct_Curve.h"
 
 ShapeConstruct_Curve * hs_new_ShapeConstruct_Curve(){
@@ -12,10 +13,17 @@ void hs_delete_ShapeConstruct_Curve(ShapeConstruct_Curve* shapeConstruct){
 
 Handle(Geom_BSplineCurve) * hs_ShapeConstruct_Curve_convertToBSpline(
         ShapeConstruct_Curve* shapeConstruct,
-        Handle(Geom_Curve)* curve, 
+        Handle(Geom_Curve)* curve,
         double first,
         double last,
-        double precision
+        double precision,
+        HSExceptionType* exType, void ** exPtr
     ){
-        return new opencascade::handle(shapeConstruct->ConvertToBSpline(*curve, first, last, precision));
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [shapeConstruct, curve, first, last, precision]{
+            return new opencascade::handle(shapeConstruct->ConvertToBSpline(*curve, first, last, precision));
+        }
+    );
 }

--- a/opencascade-hs/cpp/hs_ShapeConstruct_Curve.h
+++ b/opencascade-hs/cpp/hs_ShapeConstruct_Curve.h
@@ -13,10 +13,11 @@ void hs_delete_ShapeConstruct_Curve(ShapeConstruct_Curve* shapeConstruct);
 
 Handle(Geom_BSplineCurve) * hs_ShapeConstruct_Curve_convertToBSpline(
         ShapeConstruct_Curve* shapeConstruct,
-        Handle(Geom_Curve)* curve, 
+        Handle(Geom_Curve)* curve,
         double first,
         double last,
-        double precision
+        double precision,
+        HSExceptionType* exType, void ** exPtr
     );
 
 #ifdef __cplusplus

--- a/opencascade-hs/cpp/hs_ShapeExtend_WireData.cpp
+++ b/opencascade-hs/cpp/hs_ShapeExtend_WireData.cpp
@@ -1,25 +1,62 @@
 #include <ShapeExtend_WireData.hxx>
+#include "hs_Exception.h"
 #include "hs_ShapeExtend_WireData.h"
 
 #include <TopoDS_Wire.hxx>
 
-ShapeExtend_WireData * hs_new_ShapeExtend_WireData_fromWireChainedAndManifold(TopoDS_Wire* wire, bool chained, bool manifoldMode){
-    return new ShapeExtend_WireData(*wire, chained, manifoldMode);
+ShapeExtend_WireData * hs_new_ShapeExtend_WireData_fromWireChainedAndManifold(
+        TopoDS_Wire* wire, bool chained, bool manifoldMode,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [wire, chained, manifoldMode]{
+            return new ShapeExtend_WireData(*wire, chained, manifoldMode);
+        }
+    );
 }
 
 void hs_delete_ShapeExtend_WireData(ShapeExtend_WireData * wireData){
     delete wireData;
 }
 
-void hs_ShapeExtend_WireData_reverse(ShapeExtend_WireData * wireData){
-    wireData->Reverse();
+void hs_ShapeExtend_WireData_reverse(
+        ShapeExtend_WireData * wireData,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [wireData]{
+            wireData->Reverse();
+        }
+    );
 }
 
-TopoDS_Wire * hs_ShapeExtend_WireData_wire(ShapeExtend_WireData * wireData){
-    return new TopoDS_Wire(wireData->Wire());
+TopoDS_Wire * hs_ShapeExtend_WireData_wire(
+        ShapeExtend_WireData * wireData,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [wireData]{
+            return new TopoDS_Wire(wireData->Wire());
+        }
+    );
 }
 
 
-TopoDS_Wire * hs_ShapeExtend_WireData_wireAPIMake(ShapeExtend_WireData * wireData){
-    return new TopoDS_Wire(wireData->WireAPIMake());
+TopoDS_Wire * hs_ShapeExtend_WireData_wireAPIMake(
+        ShapeExtend_WireData * wireData,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [wireData]{
+            return new TopoDS_Wire(wireData->WireAPIMake());
+        }
+    );
 }

--- a/opencascade-hs/cpp/hs_ShapeExtend_WireData.h
+++ b/opencascade-hs/cpp/hs_ShapeExtend_WireData.h
@@ -7,15 +7,27 @@
 extern "C" {
 #endif
 
-ShapeExtend_WireData * hs_new_ShapeExtend_WireData_fromWireChainedAndManifold(TopoDS_Wire* wire, bool chained, bool manifoldMode);
+ShapeExtend_WireData * hs_new_ShapeExtend_WireData_fromWireChainedAndManifold(
+    TopoDS_Wire* wire, bool chained, bool manifoldMode,
+    HSExceptionType* exType, void ** exPtr
+);
 
 void hs_delete_ShapeExtend_WireData(ShapeExtend_WireData * wireData);
 
-void hs_ShapeExtend_WireData_reverse(ShapeExtend_WireData * wireData);
+void hs_ShapeExtend_WireData_reverse(
+    ShapeExtend_WireData * wireData,
+    HSExceptionType* exType, void ** exPtr
+);
 
-TopoDS_Wire * hs_ShapeExtend_WireData_wire(ShapeExtend_WireData * wireData);
+TopoDS_Wire * hs_ShapeExtend_WireData_wire(
+    ShapeExtend_WireData * wireData,
+    HSExceptionType* exType, void ** exPtr
+);
 
-TopoDS_Wire * hs_ShapeExtend_WireData_wireAPIMake(ShapeExtend_WireData * wireData);
+TopoDS_Wire * hs_ShapeExtend_WireData_wireAPIMake(
+    ShapeExtend_WireData * wireData,
+    HSExceptionType* exType, void ** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_ShapeFix_Solid.cpp
+++ b/opencascade-hs/cpp/hs_ShapeFix_Solid.cpp
@@ -1,30 +1,68 @@
 #include <Message_ProgressRange.hxx>
 #include <ShapeFix_Solid.hxx>
 #include <TopoDS_Solid.hxx>
+#include "hs_Exception.h"
 #include "hs_ShapeFix_Solid.h"
 
 ShapeFix_Solid * hs_new_ShapeFix_Solid(){
     return new ShapeFix_Solid();
 }
 
-ShapeFix_Solid * hs_new_ShapeFix_Solid_fromSolid(TopoDS_Solid * solid){
-    return new ShapeFix_Solid(*solid);
+ShapeFix_Solid * hs_new_ShapeFix_Solid_fromSolid(
+        TopoDS_Solid * solid,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [solid]{
+            return new ShapeFix_Solid(*solid);
+        }
+    );
 }
 
 void hs_delete_ShapeFix_Solid(ShapeFix_Solid * shapeFix){
     delete shapeFix;
 }
 
-TopoDS_Solid * hs_ShapeFix_Solid_solidFromShell(ShapeFix_Solid * shapeFix, TopoDS_Shell * shell){
-    return new TopoDS_Solid(shapeFix->SolidFromShell(*shell));
+TopoDS_Solid * hs_ShapeFix_Solid_solidFromShell(
+        ShapeFix_Solid * shapeFix, TopoDS_Shell * shell,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [shapeFix, shell]{
+            return new TopoDS_Solid(shapeFix->SolidFromShell(*shell));
+        }
+    );
 }
 
-bool hs_ShapeFix_Solid_perform(ShapeFix_Solid * shapeFix, Message_ProgressRange * progress){
-    return shapeFix->Perform(*progress);
+bool hs_ShapeFix_Solid_perform(
+        ShapeFix_Solid * shapeFix, Message_ProgressRange * progress,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleExWithDefault(
+        exType,
+        exPtr,
+        [shapeFix, progress]{
+            return shapeFix->Perform(*progress);
+        },
+        false
+    );
 }
 
-TopoDS_Shape * hs_ShapeFix_Solid_solid(ShapeFix_Solid * shapeFix){
-    return new TopoDS_Shape(shapeFix->Solid());
+TopoDS_Shape * hs_ShapeFix_Solid_solid(
+        ShapeFix_Solid * shapeFix,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [shapeFix]{
+            return new TopoDS_Shape(shapeFix->Solid());
+        }
+    );
 }
 
 bool hs_ShapeFix_Solid_status(ShapeFix_Solid * shapeFix, ShapeExtend_Status status){

--- a/opencascade-hs/cpp/hs_ShapeFix_Solid.h
+++ b/opencascade-hs/cpp/hs_ShapeFix_Solid.h
@@ -9,15 +9,27 @@ extern "C" {
 
 ShapeFix_Solid * hs_new_ShapeFix_Solid();
 
-ShapeFix_Solid * hs_new_ShapeFix_Solid_fromSolid(TopoDS_Solid * solid);
+ShapeFix_Solid * hs_new_ShapeFix_Solid_fromSolid(
+    TopoDS_Solid * solid,
+    HSExceptionType* exType, void ** exPtr
+);
 
 void hs_delete_ShapeFix_Solid(ShapeFix_Solid * shapeFix);
 
-TopoDS_Solid * hs_ShapeFix_Solid_solidFromShell(ShapeFix_Solid * shapeFix, TopoDS_Shell * shell);
+TopoDS_Solid * hs_ShapeFix_Solid_solidFromShell(
+    ShapeFix_Solid * shapeFix, TopoDS_Shell * shell,
+    HSExceptionType* exType, void ** exPtr
+);
 
-bool hs_ShapeFix_Solid_perform(ShapeFix_Solid * shapeFix, Message_ProgressRange * progress);
+bool hs_ShapeFix_Solid_perform(
+    ShapeFix_Solid * shapeFix, Message_ProgressRange * progress,
+    HSExceptionType* exType, void ** exPtr
+);
 
-TopoDS_Shape * hs_ShapeFix_Solid_solid(ShapeFix_Solid * shapeFix);
+TopoDS_Shape * hs_ShapeFix_Solid_solid(
+    ShapeFix_Solid * shapeFix,
+    HSExceptionType* exType, void ** exPtr
+);
 
 bool hs_ShapeFix_Solid_status(ShapeFix_Solid * shapeFix, ShapeExtend_Status status);
 

--- a/opencascade-hs/cpp/hs_Standard_Failure.cpp
+++ b/opencascade-hs/cpp/hs_Standard_Failure.cpp
@@ -5,6 +5,10 @@ void hs_delete_Standard_Failure(Standard_Failure *ex) {
     delete ex;
 }
 
+char * hs_Standard_Failure_GetMessageString(Standard_Failure *ex) {
+    return const_cast<char *>(ex->GetMessageString());
+}
+
 char * hs_Standard_Failure_GetStackString(Standard_Failure *ex) {
     return const_cast<char *>(ex->GetStackString());
 }

--- a/opencascade-hs/cpp/hs_Standard_Failure.cpp
+++ b/opencascade-hs/cpp/hs_Standard_Failure.cpp
@@ -1,0 +1,10 @@
+#include <Standard_Failure.hxx>
+#include "hs_Standard_Failure.h"
+
+void hs_delete_Standard_Failure(Standard_Failure *ex) {
+    delete ex;
+}
+
+char * hs_Standard_Failure_GetStackString(Standard_Failure *ex) {
+    return const_cast<char *>(ex->GetStackString());
+}

--- a/opencascade-hs/cpp/hs_Standard_Failure.h
+++ b/opencascade-hs/cpp/hs_Standard_Failure.h
@@ -9,6 +9,8 @@ extern "C" {
 
 void hs_delete_Standard_Failure(Standard_Failure * ex);
 
+char * hs_Standard_Failure_GetMessageString(Standard_Failure * ex);
+
 char * hs_Standard_Failure_GetStackString(Standard_Failure * ex);
 
 #ifdef __cplusplus

--- a/opencascade-hs/cpp/hs_Standard_Failure.h
+++ b/opencascade-hs/cpp/hs_Standard_Failure.h
@@ -1,0 +1,18 @@
+#ifndef HS_STANDARD_FAILURE_H
+#define HS_STANDARD_FAILURE_H
+
+#include "hs_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void hs_delete_Standard_Failure(Standard_Failure * ex);
+
+char * hs_Standard_Failure_GetStackString(Standard_Failure * ex);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // HS_STANDARD_FAILURE_H

--- a/opencascade-hs/cpp/hs_StlAPI_Reader.cpp
+++ b/opencascade-hs/cpp/hs_StlAPI_Reader.cpp
@@ -1,4 +1,5 @@
 #include <StlAPI_Writer.hxx>
+#include "hs_Exception.h"
 #include "hs_StlAPI_Writer.h"
 
 StlAPI_Writer * hs_new_StlAPI_Writer(){
@@ -13,6 +14,16 @@ void hs_StlAPI_Writer_setAsciiMode(StlAPI_Writer * writer, bool asciiMode){
     writer->ASCIIMode() = asciiMode;
 }
 
-bool hs_StlAPI_Writer_write(StlAPI_Writer * writer, TopoDS_Shape * shape, char* filename){
-    return writer->Write(*shape, filename);
+bool hs_StlAPI_Writer_write(
+    StlAPI_Writer * writer, TopoDS_Shape * shape, char* filename,
+    HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleExWithDefault(
+        exType,
+        exPtr,
+        [writer, shape, filename]{
+            return writer->Write(*shape, filename);
+        },
+        false
+    );
 } 

--- a/opencascade-hs/cpp/hs_StlAPI_Reader.h
+++ b/opencascade-hs/cpp/hs_StlAPI_Reader.h
@@ -13,7 +13,10 @@ StlAPI_Reader * hs_new_StlAPI_Reader();
 
 void hs_delete_StlAPI_Reader(StlAPI_Reader * reader);
 
-bool hs_StlAPI_Reader_read(StlAPI_Reader * reader, TopoDS_Shape * shape, char* filename);
+bool hs_StlAPI_Reader_read(
+    StlAPI_Reader * reader, TopoDS_Shape * shape, char* filename,
+    HSExceptionType* exType, void ** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_StlAPI_Writer.cpp
+++ b/opencascade-hs/cpp/hs_StlAPI_Writer.cpp
@@ -1,4 +1,6 @@
 #include <StlAPI_Reader.hxx>
+#include <Standard_Failure.hxx>
+#include "hs_Exception.h"
 #include "hs_StlAPI_Reader.h"
 
 StlAPI_Reader * hs_new_StlAPI_Reader(){
@@ -9,6 +11,16 @@ void hs_delete_StlAPI_Reader(StlAPI_Reader * reader){
     delete reader;
 }
 
-bool hs_StlAPI_Reader_read(StlAPI_Reader * reader, TopoDS_Shape * shape, char* filename){
-    return reader->Read(*shape, filename);
+bool hs_StlAPI_Reader_read(
+    StlAPI_Reader * reader, TopoDS_Shape * shape, char* filename,
+    HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleExWithDefault(
+        exType,
+        exPtr,
+        [reader, shape, filename]{
+            return reader->Read(*shape, filename);
+        },
+        false
+    );
 } 

--- a/opencascade-hs/cpp/hs_StlAPI_Writer.h
+++ b/opencascade-hs/cpp/hs_StlAPI_Writer.h
@@ -14,7 +14,10 @@ void hs_delete_StlAPI_Writer(StlAPI_Writer * writer);
 
 void hs_StlAPI_Writer_setAsciiMode(StlAPI_Writer * writer, bool asciiMode);
 
-bool hs_StlAPI_Writer_write(StlAPI_Writer * writer, TopoDS_Shape * shape, char* filename);
+bool hs_StlAPI_Writer_write(
+    StlAPI_Writer * writer, TopoDS_Shape * shape, char* filename,
+    HSExceptionType* exType, void ** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_TDocStd_Document.cpp
+++ b/opencascade-hs/cpp/hs_TDocStd_Document.cpp
@@ -1,15 +1,26 @@
 #include <TDocStd_Document.hxx>
 #include <XCAFDoc_ShapeTool.hxx>
+#include "hs_Exception.h"
 #include "hs_TDocStd_Document.h"
 
-Handle(TDocStd_Document) * hs_new_TDocStd_Document(char * storageFormat){
-    return new opencascade::handle<TDocStd_Document>(new TDocStd_Document(storageFormat));
+Handle(TDocStd_Document) * hs_new_TDocStd_Document(
+        char * storageFormat,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(exType, exPtr, [storageFormat]{
+        return new opencascade::handle<TDocStd_Document>(new TDocStd_Document(storageFormat));
+    });
 }
 
 void hs_delete_TDocStd_Document(Handle(TDocStd_Document) * theDocument){
     delete theDocument;
 }
 
-TDF_Label * hs_TDocStd_Document_main(Handle(TDocStd_Document) *theDocument){
-    return new TDF_Label(theDocument->get()->Main());
+TDF_Label * hs_TDocStd_Document_main(
+        Handle(TDocStd_Document) *theDocument,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(exType, exPtr, [theDocument]{
+        return new TDF_Label(theDocument->get()->Main());
+    });
 }

--- a/opencascade-hs/cpp/hs_TDocStd_Document.h
+++ b/opencascade-hs/cpp/hs_TDocStd_Document.h
@@ -7,11 +7,17 @@
 extern "C" {
 #endif
 
-Handle(TDocStd_Document) * hs_new_TDocStd_Document(char * storageFormat);
+Handle(TDocStd_Document) * hs_new_TDocStd_Document(
+    char * storageFormat,
+    HSExceptionType* exType, void ** exPtr
+);
 
 void hs_delete_TDocStd_Document(Handle(TDocStd_Document) * theDocument);
 
-TDF_Label * hs_TDocStd_Document_main(Handle(TDocStd_Document) *theDocument);
+TDF_Label * hs_TDocStd_Document_main(
+    Handle(TDocStd_Document) *theDocument,
+    HSExceptionType* exType, void ** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_TopExp_Explorer.cpp
+++ b/opencascade-hs/cpp/hs_TopExp_Explorer.cpp
@@ -1,8 +1,18 @@
 #include <TopExp_Explorer.hxx>
+#include "hs_Exception.h"
 #include "hs_TopExp_Explorer.h"
 
-TopExp_Explorer * hs_new_TopExp_Explorer(TopoDS_Shape * shape, TopAbs_ShapeEnum toFind){
-    return new TopExp_Explorer(*shape, toFind);
+TopExp_Explorer * hs_new_TopExp_Explorer(
+        TopoDS_Shape * shape, TopAbs_ShapeEnum toFind,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [shape, toFind]{
+            return new TopExp_Explorer(*shape, toFind);
+        }
+    );
 }
 
 void hs_delete_TopExp_Explorer(TopExp_Explorer * explorer){
@@ -13,10 +23,28 @@ bool hs_TopExp_Explorer_more(TopExp_Explorer * explorer){
     return explorer->More();
 }
 
-void hs_TopExp_Explorer_next(TopExp_Explorer * explorer){
-    return explorer->Next();
+void hs_TopExp_Explorer_next(
+        TopExp_Explorer * explorer,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(
+        exType,
+        exPtr,
+        [explorer]{
+            explorer->Next();
+        }
+    );
 }
 
-TopoDS_Shape * hs_TopExp_Explorer_value(TopExp_Explorer * explorer){
-    return (TopoDS_Shape *) &(explorer->Value());
+TopoDS_Shape * hs_TopExp_Explorer_value(
+        TopExp_Explorer * explorer,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [explorer]{
+            return (TopoDS_Shape *) &(explorer->Value());
+        }
+    );
 }

--- a/opencascade-hs/cpp/hs_TopExp_Explorer.h
+++ b/opencascade-hs/cpp/hs_TopExp_Explorer.h
@@ -7,15 +7,24 @@
 extern "C" {
 #endif
 
-TopExp_Explorer * hs_new_TopExp_Explorer(TopoDS_Shape * shape, TopAbs_ShapeEnum toFind);
+TopExp_Explorer * hs_new_TopExp_Explorer(
+    TopoDS_Shape * shape, TopAbs_ShapeEnum toFind,
+    HSExceptionType* exType, void ** exPtr
+);
 
 void hs_delete_TopExp_Explorer(TopExp_Explorer * explorer);
 
 bool hs_TopExp_Explorer_more(TopExp_Explorer * explorer);
 
-void hs_TopExp_Explorer_next(TopExp_Explorer * explorer);
+void hs_TopExp_Explorer_next(
+    TopExp_Explorer * explorer,
+    HSExceptionType* exType, void ** exPtr
+);
 
-TopoDS_Shape * hs_TopExp_Explorer_value(TopExp_Explorer * explorer);
+TopoDS_Shape * hs_TopExp_Explorer_value(
+    TopExp_Explorer * explorer,
+    HSExceptionType* exType, void ** exPtr
+);
 #ifdef __cplusplus
 }
 #endif

--- a/opencascade-hs/cpp/hs_TopLoc_Location.cpp
+++ b/opencascade-hs/cpp/hs_TopLoc_Location.cpp
@@ -1,4 +1,5 @@
 #include <TopLoc_Location.hxx>
+#include "hs_Exception.h"
 #include "hs_TopLoc_Location.h"
 
 TopLoc_Location * hs_new_TopLoc_Location(){
@@ -21,28 +22,58 @@ int hs_TopLoc_Location_FirstPower(TopLoc_Location * l){
     return l->FirstPower();
 }
 
-TopLoc_Location * hs_TopLoc_Location_NextLocation(TopLoc_Location * l){
-    return new TopLoc_Location(l->NextLocation());
+TopLoc_Location * hs_TopLoc_Location_NextLocation(
+        TopLoc_Location * l,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(exType, exPtr, [l]{
+        return new TopLoc_Location(l->NextLocation());
+    });
 }
 
-TopLoc_Location * hs_TopLoc_Location_Inverted(TopLoc_Location * l){
-    return new TopLoc_Location(l->Inverted());
+TopLoc_Location * hs_TopLoc_Location_Inverted(
+        TopLoc_Location * l,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(exType, exPtr, [l]{
+        return new TopLoc_Location(l->Inverted());
+    });
 }
 
-TopLoc_Location * hs_TopLoc_Location_Multiplied(TopLoc_Location * a, TopLoc_Location * b){
-    return new TopLoc_Location(a->Multiplied(*b));
+TopLoc_Location * hs_TopLoc_Location_Multiplied(
+        TopLoc_Location * a, TopLoc_Location * b,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(exType, exPtr, [a, b]{
+        return new TopLoc_Location(a->Multiplied(*b));
+    });
 }
 
-TopLoc_Location * hs_TopLoc_Location_Divided(TopLoc_Location * a, TopLoc_Location * b){
-    return new TopLoc_Location(a->Divided(*b));
+TopLoc_Location * hs_TopLoc_Location_Divided(
+        TopLoc_Location * a, TopLoc_Location * b,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(exType, exPtr, [a, b]{
+        return new TopLoc_Location(a->Divided(*b));
+    });
 }
 
-TopLoc_Location * hs_TopLoc_Location_Predivided(TopLoc_Location * a, TopLoc_Location * b){
-    return new TopLoc_Location(a->Predivided(*b));
+TopLoc_Location * hs_TopLoc_Location_Predivided(
+        TopLoc_Location * a, TopLoc_Location * b,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(exType, exPtr, [a, b]{
+        return new TopLoc_Location(a->Predivided(*b));
+    });
 }
 
-TopLoc_Location * hs_TopLoc_Location_Powered(TopLoc_Location * l, int p){
-    return new TopLoc_Location(l->Powered(p));
+TopLoc_Location * hs_TopLoc_Location_Powered(
+        TopLoc_Location * l, int p,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(exType, exPtr, [l, p]{
+        return new TopLoc_Location(l->Powered(p));
+    });
 }
 
 gp_Trsf * hs_TopLoc_Location_toGPTrsf(TopLoc_Location * l){

--- a/opencascade-hs/cpp/hs_TopLoc_Location.h
+++ b/opencascade-hs/cpp/hs_TopLoc_Location.h
@@ -17,17 +17,35 @@ bool hs_TopLoc_Location_IsIdentity(TopLoc_Location * l);
 
 int hs_TopLoc_Location_FirstPower(TopLoc_Location * l);
 
-TopLoc_Location * hs_TopLoc_Location_NextLocation(TopLoc_Location * l);
+TopLoc_Location * hs_TopLoc_Location_NextLocation(
+    TopLoc_Location * l,
+    HSExceptionType* exType, void ** exPtr
+);
 
-TopLoc_Location * hs_TopLoc_Location_Inverted(TopLoc_Location * l);
+TopLoc_Location * hs_TopLoc_Location_Inverted(
+    TopLoc_Location * l,
+    HSExceptionType* exType, void ** exPtr
+);
 
-TopLoc_Location * hs_TopLoc_Location_Multiplied(TopLoc_Location * a, TopLoc_Location * b);
+TopLoc_Location * hs_TopLoc_Location_Multiplied(
+    TopLoc_Location * a, TopLoc_Location * b,
+    HSExceptionType* exType, void ** exPtr
+);
 
-TopLoc_Location * hs_TopLoc_Location_Divided(TopLoc_Location * a, TopLoc_Location * b);
+TopLoc_Location * hs_TopLoc_Location_Divided(
+    TopLoc_Location * a, TopLoc_Location * b,
+    HSExceptionType* exType, void ** exPtr
+);
 
-TopLoc_Location * hs_TopLoc_Location_Predivided(TopLoc_Location * a, TopLoc_Location * b);
+TopLoc_Location * hs_TopLoc_Location_Predivided(
+    TopLoc_Location * a, TopLoc_Location * b,
+    HSExceptionType* exType, void ** exPtr
+);
 
-TopLoc_Location * hs_TopLoc_Location_Powered(TopLoc_Location * l, int p);
+TopLoc_Location * hs_TopLoc_Location_Powered(
+    TopLoc_Location * l, int p,
+    HSExceptionType* exType, void ** exPtr
+);
 
 gp_Trsf * hs_TopLoc_Location_toGPTrsf(TopLoc_Location * l);
 

--- a/opencascade-hs/cpp/hs_TopTools_ShapeMapHasher.cpp
+++ b/opencascade-hs/cpp/hs_TopTools_ShapeMapHasher.cpp
@@ -1,12 +1,27 @@
 #include <TopTools_ShapeMapHasher.hxx>
+#include "hs_Exception.h"
 #include "hs_TopTools_ShapeMapHasher.h"
 
-int hs_TopTools_ShapeMapHasher_hash(TopoDS_Shape * shape){
-    auto hasher = TopTools_ShapeMapHasher();
-    return hasher(*shape);
+int hs_TopTools_ShapeMapHasher_hash(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(
+        exType, 
+        exPtr, 
+        [shape]{
+            auto hasher = TopTools_ShapeMapHasher();
+            return hasher(*shape);
+        }, 
+        0
+    );
 }
 
-bool hs_TopTools_ShapeMapHasher_isEqual(TopoDS_Shape * shapeA, TopoDS_Shape * shapeB){
-    auto hasher = TopTools_ShapeMapHasher();
-    return hasher(*shapeA, *shapeB);
+bool hs_TopTools_ShapeMapHasher_isEqual(TopoDS_Shape * shapeA, TopoDS_Shape * shapeB, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(
+        exType, 
+        exPtr, 
+        [shapeA, shapeB]{
+            auto hasher = TopTools_ShapeMapHasher();
+            return hasher(*shapeA, *shapeB);
+        }, 
+        false
+    );
 }

--- a/opencascade-hs/cpp/hs_TopTools_ShapeMapHasher.h
+++ b/opencascade-hs/cpp/hs_TopTools_ShapeMapHasher.h
@@ -7,9 +7,9 @@
 extern "C" {
 #endif
 
-int hs_TopTools_ShapeMapHasher_hash(TopoDS_Shape * shape);
+int hs_TopTools_ShapeMapHasher_hash(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr);
 
-bool hs_TopTools_ShapeMapHasher_isEqual(TopoDS_Shape * shapeA, TopoDS_Shape * shapeB);
+bool hs_TopTools_ShapeMapHasher_isEqual(TopoDS_Shape * shapeA, TopoDS_Shape * shapeB, HSExceptionType* exType, void ** exPtr);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_TopoDS_Builder.cpp
+++ b/opencascade-hs/cpp/hs_TopoDS_Builder.cpp
@@ -1,4 +1,5 @@
 #include <TopoDS_Builder.hxx>
+#include "hs_Exception.h"
 #include "hs_TopoDS_Builder.h"
 
 TopoDS_Builder * hs_new_TopoDS_Builder(void){
@@ -10,33 +11,68 @@ void hs_delete_TopoDS_Builder(TopoDS_Builder * builder){
 }
 
 
-void hs_TopoDS_Builder_makeWire(TopoDS_Builder * builder, TopoDS_Wire * wire){
-    builder->MakeWire(*wire);
+void hs_TopoDS_Builder_makeWire(
+        TopoDS_Builder * builder, TopoDS_Wire * wire,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(exType, exPtr, [builder, wire]{
+        builder->MakeWire(*wire);
+    });
 }
 
 
-void hs_TopoDS_Builder_makeShell(TopoDS_Builder * builder, TopoDS_Shell * shell){
-    builder->MakeShell(*shell);
+void hs_TopoDS_Builder_makeShell(
+        TopoDS_Builder * builder, TopoDS_Shell * shell,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(exType, exPtr, [builder, shell]{
+        builder->MakeShell(*shell);
+    });
 }
 
-void hs_TopoDS_Builder_makeSolid(TopoDS_Builder * builder, TopoDS_Solid * solid){
-    builder->MakeSolid(*solid);
+void hs_TopoDS_Builder_makeSolid(
+        TopoDS_Builder * builder, TopoDS_Solid * solid,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(exType, exPtr, [builder, solid]{
+        builder->MakeSolid(*solid);
+    });
 }
 
-void hs_TopoDS_Builder_makeCompSolid(TopoDS_Builder * builder, TopoDS_CompSolid * solid){
-    builder->MakeCompSolid(*solid);
+void hs_TopoDS_Builder_makeCompSolid(
+        TopoDS_Builder * builder, TopoDS_CompSolid * solid,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(exType, exPtr, [builder, solid]{
+        builder->MakeCompSolid(*solid);
+    });
 }
 
-void hs_TopoDS_Builder_makeCompound(TopoDS_Builder * builder, TopoDS_Compound * compound){
-    builder->MakeCompound(*compound);
+void hs_TopoDS_Builder_makeCompound(
+        TopoDS_Builder * builder, TopoDS_Compound * compound,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(exType, exPtr, [builder, compound]{
+        builder->MakeCompound(*compound);
+    });
 }
 
-void hs_TopoDS_Builder_add(TopoDS_Builder * builder, TopoDS_Shape * s, TopoDS_Shape * c){
-    builder->Add(*s, *c);
+void hs_TopoDS_Builder_add(
+        TopoDS_Builder * builder, TopoDS_Shape * s, TopoDS_Shape * c,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(exType, exPtr, [builder, s, c]{
+        builder->Add(*s, *c);
+    });
 }
 
-void hs_TopoDS_Builder_remove(TopoDS_Builder * builder, TopoDS_Shape * s, TopoDS_Shape * c){
-    builder->Remove(*s, *c);
+void hs_TopoDS_Builder_remove(
+        TopoDS_Builder * builder, TopoDS_Shape * s, TopoDS_Shape * c,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(exType, exPtr, [builder, s, c]{
+        builder->Remove(*s, *c);
+    });
 }
 
 

--- a/opencascade-hs/cpp/hs_TopoDS_Builder.h
+++ b/opencascade-hs/cpp/hs_TopoDS_Builder.h
@@ -11,19 +11,40 @@ TopoDS_Builder * hs_new_TopoDS_Builder(void);
 
 void hs_delete_TopoDS_Builder(TopoDS_Builder * builder);
 
-void hs_TopoDS_Builder_makeWire(TopoDS_Builder * builder, TopoDS_Wire * wire);
+void hs_TopoDS_Builder_makeWire(
+    TopoDS_Builder * builder, TopoDS_Wire * wire,
+    HSExceptionType* exType, void ** exPtr
+);
 
-void hs_TopoDS_Builder_makeShell(TopoDS_Builder * builder, TopoDS_Shell * shell);
+void hs_TopoDS_Builder_makeShell(
+    TopoDS_Builder * builder, TopoDS_Shell * shell,
+    HSExceptionType* exType, void ** exPtr
+);
 
-void hs_TopoDS_Builder_makeSolid(TopoDS_Builder * builder, TopoDS_Solid * solid);
+void hs_TopoDS_Builder_makeSolid(
+    TopoDS_Builder * builder, TopoDS_Solid * solid,
+    HSExceptionType* exType, void ** exPtr
+);
 
-void hs_TopoDS_Builder_makeCompSolid(TopoDS_Builder * builder, TopoDS_CompSolid * solid);
+void hs_TopoDS_Builder_makeCompSolid(
+    TopoDS_Builder * builder, TopoDS_CompSolid * solid,
+    HSExceptionType* exType, void ** exPtr
+);
 
-void hs_TopoDS_Builder_makeCompound(TopoDS_Builder * builder, TopoDS_Compound * compound);
+void hs_TopoDS_Builder_makeCompound(
+    TopoDS_Builder * builder, TopoDS_Compound * compound,
+    HSExceptionType* exType, void ** exPtr
+);
 
-void hs_TopoDS_Builder_add(TopoDS_Builder * builder, TopoDS_Shape * s, TopoDS_Shape * c);
+void hs_TopoDS_Builder_add(
+    TopoDS_Builder * builder, TopoDS_Shape * s, TopoDS_Shape * c,
+    HSExceptionType* exType, void ** exPtr
+);
 
-void hs_TopoDS_Builder_remove(TopoDS_Builder * builder, TopoDS_Shape * s, TopoDS_Shape * c);
+void hs_TopoDS_Builder_remove(
+    TopoDS_Builder * builder, TopoDS_Shape * s, TopoDS_Shape * c,
+    HSExceptionType* exType, void ** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_TopoDS_Shape.cpp
+++ b/opencascade-hs/cpp/hs_TopoDS_Shape.cpp
@@ -1,4 +1,5 @@
 #include <TopoDS_Shape.hxx>
+#include "hs_Exception.h"
 #include "hs_TopoDS_Shape.h"
 
 TopoDS_Shape * hs_new_TopoDS_Shape(){
@@ -13,169 +14,249 @@ void hs_delete_TopoDS_Shape(TopoDS_Shape * shape){
     delete shape;
 }
 
-bool hs_TopoDS_Shape_IsNull(TopoDS_Shape * shape){
-    return shape->IsNull();
+bool hs_TopoDS_Shape_IsNull(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(exType, exPtr, [shape]{
+        return shape->IsNull();
+    }, false);
 }
 
-void hs_TopoDS_Shape_Nullify(TopoDS_Shape * shape){
-    shape->Nullify();
+void hs_TopoDS_Shape_Nullify(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [shape]{
+        shape->Nullify();
+    });
 }
 
-TopLoc_Location * hs_TopoDS_Shape_Location(TopoDS_Shape * shape){
-    return new TopLoc_Location(shape->Location());
+TopLoc_Location * hs_TopoDS_Shape_Location(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr){
+    return hs_handleEx(exType, exPtr, [shape]{
+        return new TopLoc_Location(shape->Location());
+    });
 }
 
-void hs_TopoDS_Shape_SetLocation(TopoDS_Shape * shape, TopLoc_Location * location){
-    shape->Location(*location);
+void hs_TopoDS_Shape_SetLocation(TopoDS_Shape * shape, TopLoc_Location * location, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [shape, location]{
+        shape->Location(*location);
+    });
 }
 
-TopoDS_Shape * hs_TopoDS_Shape_Located(TopoDS_Shape * shape, TopLoc_Location * location){
-    return new TopoDS_Shape(shape->Located(*location));
+TopoDS_Shape * hs_TopoDS_Shape_Located(TopoDS_Shape * shape, TopLoc_Location * location, HSExceptionType* exType, void ** exPtr){
+    return hs_handleEx(exType, exPtr, [shape, location]{
+        return new TopoDS_Shape(shape->Located(*location));
+    });
 }
 
-TopAbs_Orientation hs_TopoDS_Shape_Orientation(TopoDS_Shape * shape){
-    return shape->Orientation();
+TopAbs_Orientation hs_TopoDS_Shape_Orientation(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(exType, exPtr, [shape]{
+        return shape->Orientation();
+    }, static_cast<TopAbs_Orientation>(0));
 }
 
-void hs_TopoDS_Shape_SetOrientation(TopoDS_Shape * shape, TopAbs_Orientation orientation){
-    return shape->Orientation(orientation);
+void hs_TopoDS_Shape_SetOrientation(TopoDS_Shape * shape, TopAbs_Orientation orientation, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [shape, orientation]{
+        shape->Orientation(orientation);
+    });
 }
 
-TopoDS_Shape * hs_TopoDS_Shape_Oriented(TopoDS_Shape * shape, TopAbs_Orientation orientation){
-    return new TopoDS_Shape(shape->Oriented(orientation));
+TopoDS_Shape * hs_TopoDS_Shape_Oriented(TopoDS_Shape * shape, TopAbs_Orientation orientation, HSExceptionType* exType, void ** exPtr){
+    return hs_handleEx(exType, exPtr, [shape, orientation]{
+        return new TopoDS_Shape(shape->Oriented(orientation));
+    });
 }
 
-TopAbs_ShapeEnum hs_TopoDS_Shape_ShapeType(TopoDS_Shape * shape){
-    return shape->ShapeType();
+TopAbs_ShapeEnum hs_TopoDS_Shape_ShapeType(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(exType, exPtr, [shape]{
+        return shape->ShapeType();
+    }, static_cast<TopAbs_ShapeEnum>(0));
 }
 
-bool hs_TopoDS_Shape_Free(TopoDS_Shape * shape){
-    return shape->Free();
+bool hs_TopoDS_Shape_Free(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(exType, exPtr, [shape]{
+        return shape->Free();
+    }, false);
 }
 
-void hs_TopoDS_Shape_SetFree(TopoDS_Shape * shape, bool b){
-    shape->Free(b);
-}
-
-
-bool hs_TopoDS_Shape_Locked(TopoDS_Shape * shape){
-    return shape->Locked();
-}
-
-void hs_TopoDS_Shape_SetLocked(TopoDS_Shape * shape, bool b){
-    shape->Locked(b);
-}
-
-bool hs_TopoDS_Shape_Modified(TopoDS_Shape * shape){
-    return shape->Modified();
-}
-
-void hs_TopoDS_Shape_SetModified(TopoDS_Shape * shape, bool b){
-    shape->Modified(b);
-}
-
-
-bool hs_TopoDS_Shape_Checked(TopoDS_Shape * shape){
-    return shape->Checked();
-}
-
-void hs_TopoDS_Shape_SetChecked(TopoDS_Shape * shape, bool b){
-    shape->Checked(b);
+void hs_TopoDS_Shape_SetFree(TopoDS_Shape * shape, bool b, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [shape, b]{
+        shape->Free(b);
+    });
 }
 
 
-bool hs_TopoDS_Shape_Orientable(TopoDS_Shape * shape){
-    return shape->Orientable();
+bool hs_TopoDS_Shape_Locked(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(exType, exPtr, [shape]{
+        return shape->Locked();
+    }, false);
 }
 
-void hs_TopoDS_Shape_SetOrientable(TopoDS_Shape * shape, bool b){
-    shape->Orientable(b);
+void hs_TopoDS_Shape_SetLocked(TopoDS_Shape * shape, bool b, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [shape, b]{
+        shape->Locked(b);
+    });
 }
 
-bool hs_TopoDS_Shape_Closed(TopoDS_Shape * shape){
-    return shape->Closed();
+bool hs_TopoDS_Shape_Modified(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(exType, exPtr, [shape]{
+        return shape->Modified();
+    }, false);
 }
 
-void hs_TopoDS_Shape_SetClosed(TopoDS_Shape * shape, bool b){
-    shape->Closed(b);
-}
-
-
-bool hs_TopoDS_Shape_Infinite(TopoDS_Shape * shape){
-    return shape->Infinite();
-}
-
-void hs_TopoDS_Shape_SetInfinite(TopoDS_Shape * shape, bool b){
-    shape->Infinite(b);
-}
-
-
-bool hs_TopoDS_Shape_Convex(TopoDS_Shape * shape){
-    return shape->Convex();
-}
-
-void hs_TopoDS_Shape_SetConvex(TopoDS_Shape * shape, bool b){
-    shape->Convex(b);
-}
-
-void hs_TopoDS_Shape_Move(TopoDS_Shape * shape, TopLoc_Location * position){
-    shape->Move(*position);
-}
-
-TopoDS_Shape * hs_TopoDS_Shape_Moved(TopoDS_Shape * shape, TopLoc_Location * position){
-    return new TopoDS_Shape(shape->Moved(*position));
-}
-
-int hs_TopoDS_Shape_NbChildren(TopoDS_Shape * shape){
-    return shape->NbChildren();
-}
-
-void hs_TopoDS_Shape_Reverse(TopoDS_Shape * shape){
-    shape->Reverse();
-}
-
-TopoDS_Shape * hs_TopoDS_Shape_Reversed(TopoDS_Shape * shape){
-    return new TopoDS_Shape(shape->Reversed());
+void hs_TopoDS_Shape_SetModified(TopoDS_Shape * shape, bool b, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [shape, b]{
+        shape->Modified(b);
+    });
 }
 
 
-void hs_TopoDS_Shape_Complement(TopoDS_Shape * shape){
-    shape->Complement();
+bool hs_TopoDS_Shape_Checked(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(exType, exPtr, [shape]{
+        return shape->Checked();
+    }, false);
 }
 
-TopoDS_Shape * hs_TopoDS_Shape_Complemented(TopoDS_Shape * shape){
-    return new TopoDS_Shape(shape->Complemented());
-}
-
-void hs_TopoDS_Shape_Compose(TopoDS_Shape * shape, TopAbs_Orientation orient){
-    shape->Compose(orient);
-}
-
-TopoDS_Shape * hs_TopoDS_Shape_Composed(TopoDS_Shape * shape, TopAbs_Orientation orient){
-    return new TopoDS_Shape(shape->Composed(orient));
-}
-
-bool hs_TopoDS_Shape_IsEqual(TopoDS_Shape * a, TopoDS_Shape* b){
-    return a->IsEqual(*b);
-}
-
-bool hs_TopoDS_Shape_IsSame(TopoDS_Shape * a, TopoDS_Shape* b){
-    return a->IsSame(*b);
-}
-
-bool hs_TopoDS_Shape_IsPartner(TopoDS_Shape * a, TopoDS_Shape* b){
-    return a->IsPartner(*b);
-}
-
-bool hs_TopoDS_Shape_IsNotEqual(TopoDS_Shape * a, TopoDS_Shape* b){
-    return a->IsNotEqual(*b);
+void hs_TopoDS_Shape_SetChecked(TopoDS_Shape * shape, bool b, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [shape, b]{
+        shape->Checked(b);
+    });
 }
 
 
-void hs_TopoDS_Shape_EmptyCopy(TopoDS_Shape * shape){
-    shape->EmptyCopy();
+bool hs_TopoDS_Shape_Orientable(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(exType, exPtr, [shape]{
+        return shape->Orientable();
+    }, false);
 }
 
-TopoDS_Shape * hs_TopoDS_Shape_EmptyCopied(TopoDS_Shape * shape){
-    return new TopoDS_Shape(shape->EmptyCopied());
+void hs_TopoDS_Shape_SetOrientable(TopoDS_Shape * shape, bool b, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [shape, b]{
+        shape->Orientable(b);
+    });
+}
+
+bool hs_TopoDS_Shape_Closed(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(exType, exPtr, [shape]{
+        return shape->Closed();
+    }, false);
+}
+
+void hs_TopoDS_Shape_SetClosed(TopoDS_Shape * shape, bool b, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [shape, b]{
+        shape->Closed(b);
+    });
+}
+
+
+bool hs_TopoDS_Shape_Infinite(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(exType, exPtr, [shape]{
+        return shape->Infinite();
+    }, false);
+}
+
+void hs_TopoDS_Shape_SetInfinite(TopoDS_Shape * shape, bool b, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [shape, b]{
+        shape->Infinite(b);
+    });
+}
+
+
+bool hs_TopoDS_Shape_Convex(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(exType, exPtr, [shape]{
+        return shape->Convex();
+    }, false);
+}
+
+void hs_TopoDS_Shape_SetConvex(TopoDS_Shape * shape, bool b, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [shape, b]{
+        shape->Convex(b);
+    });
+}
+
+void hs_TopoDS_Shape_Move(TopoDS_Shape * shape, TopLoc_Location * position, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [shape, position]{
+        shape->Move(*position);
+    });
+}
+
+TopoDS_Shape * hs_TopoDS_Shape_Moved(TopoDS_Shape * shape, TopLoc_Location * position, HSExceptionType* exType, void ** exPtr){
+    return hs_handleEx(exType, exPtr, [shape, position]{
+        return new TopoDS_Shape(shape->Moved(*position));
+    });
+}
+
+int hs_TopoDS_Shape_NbChildren(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(exType, exPtr, [shape]{
+        return shape->NbChildren();
+    }, 0);
+}
+
+void hs_TopoDS_Shape_Reverse(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [shape]{
+        shape->Reverse();
+    });
+}
+
+TopoDS_Shape * hs_TopoDS_Shape_Reversed(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr){
+    return hs_handleEx(exType, exPtr, [shape]{
+        return new TopoDS_Shape(shape->Reversed());
+    });
+}
+
+
+void hs_TopoDS_Shape_Complement(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [shape]{
+        shape->Complement();
+    });
+}
+
+TopoDS_Shape * hs_TopoDS_Shape_Complemented(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr){
+    return hs_handleEx(exType, exPtr, [shape]{
+        return new TopoDS_Shape(shape->Complemented());
+    });
+}
+
+void hs_TopoDS_Shape_Compose(TopoDS_Shape * shape, TopAbs_Orientation orient, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [shape, orient]{
+        shape->Compose(orient);
+    });
+}
+
+TopoDS_Shape * hs_TopoDS_Shape_Composed(TopoDS_Shape * shape, TopAbs_Orientation orient, HSExceptionType* exType, void ** exPtr){
+    return hs_handleEx(exType, exPtr, [shape, orient]{
+        return new TopoDS_Shape(shape->Composed(orient));
+    });
+}
+
+bool hs_TopoDS_Shape_IsEqual(TopoDS_Shape * a, TopoDS_Shape* b, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(exType, exPtr, [a, b]{
+        return a->IsEqual(*b);
+    }, false);
+}
+
+bool hs_TopoDS_Shape_IsSame(TopoDS_Shape * a, TopoDS_Shape* b, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(exType, exPtr, [a, b]{
+        return a->IsSame(*b);
+    }, false);
+}
+
+bool hs_TopoDS_Shape_IsPartner(TopoDS_Shape * a, TopoDS_Shape* b, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(exType, exPtr, [a, b]{
+        return a->IsPartner(*b);
+    }, false);
+}
+
+bool hs_TopoDS_Shape_IsNotEqual(TopoDS_Shape * a, TopoDS_Shape* b, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(exType, exPtr, [a, b]{
+        return a->IsNotEqual(*b);
+    }, false);
+}
+
+
+void hs_TopoDS_Shape_EmptyCopy(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [shape]{
+        shape->EmptyCopy();
+    });
+}
+
+TopoDS_Shape * hs_TopoDS_Shape_EmptyCopied(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr){
+    return hs_handleEx(exType, exPtr, [shape]{
+        return new TopoDS_Shape(shape->EmptyCopied());
+    });
 }

--- a/opencascade-hs/cpp/hs_TopoDS_Shape.h
+++ b/opencascade-hs/cpp/hs_TopoDS_Shape.h
@@ -13,89 +13,89 @@ TopoDS_Shape * hs_new_TopoDS_Shape_copy(TopoDS_Shape * shape);
 
 void hs_delete_TopoDS_Shape(TopoDS_Shape * shape);
 
-bool hs_TopoDS_Shape_IsNull(TopoDS_Shape * shape);
+bool hs_TopoDS_Shape_IsNull(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr);
 
-void hs_TopoDS_Shape_Nullify(TopoDS_Shape * shape);
+void hs_TopoDS_Shape_Nullify(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr);
 
-TopLoc_Location * hs_TopoDS_Shape_Location(TopoDS_Shape * shape);
+TopLoc_Location * hs_TopoDS_Shape_Location(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr);
 
-void hs_TopoDS_Shape_SetLocation(TopoDS_Shape * shape, TopLoc_Location * location);
+void hs_TopoDS_Shape_SetLocation(TopoDS_Shape * shape, TopLoc_Location * location, HSExceptionType* exType, void ** exPtr);
 
-TopoDS_Shape * hs_TopoDS_Shape_Located(TopoDS_Shape * shape, TopLoc_Location * location);
+TopoDS_Shape * hs_TopoDS_Shape_Located(TopoDS_Shape * shape, TopLoc_Location * location, HSExceptionType* exType, void ** exPtr);
 
-TopAbs_Orientation hs_TopoDS_Shape_Orientation(TopoDS_Shape * shape);
+TopAbs_Orientation hs_TopoDS_Shape_Orientation(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr);
 
-void hs_TopoDS_Shape_SetOrientation(TopoDS_Shape * shape, TopAbs_Orientation orientation);
+void hs_TopoDS_Shape_SetOrientation(TopoDS_Shape * shape, TopAbs_Orientation orientation, HSExceptionType* exType, void ** exPtr);
 
-TopoDS_Shape * hs_TopoDS_Shape_Oriented(TopoDS_Shape * shape, TopAbs_Orientation orientation);
+TopoDS_Shape * hs_TopoDS_Shape_Oriented(TopoDS_Shape * shape, TopAbs_Orientation orientation, HSExceptionType* exType, void ** exPtr);
 
-TopAbs_ShapeEnum hs_TopoDS_Shape_ShapeType(TopoDS_Shape * shape);
+TopAbs_ShapeEnum hs_TopoDS_Shape_ShapeType(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr);
 
-bool hs_TopoDS_Shape_Free(TopoDS_Shape * shape);
+bool hs_TopoDS_Shape_Free(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr);
 
-void hs_TopoDS_Shape_SetFree(TopoDS_Shape * shape, bool b);
+void hs_TopoDS_Shape_SetFree(TopoDS_Shape * shape, bool b, HSExceptionType* exType, void ** exPtr);
 
-bool hs_TopoDS_Shape_Locked(TopoDS_Shape * shape);
+bool hs_TopoDS_Shape_Locked(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr);
 
-void hs_TopoDS_Shape_SetLocked(TopoDS_Shape * shape, bool b);
+void hs_TopoDS_Shape_SetLocked(TopoDS_Shape * shape, bool b, HSExceptionType* exType, void ** exPtr);
 
-bool hs_TopoDS_Shape_Modified(TopoDS_Shape * shape);
+bool hs_TopoDS_Shape_Modified(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr);
 
-void hs_TopoDS_Shape_SetModified(TopoDS_Shape * shape, bool b);
-
-
-bool hs_TopoDS_Shape_Checked(TopoDS_Shape * shape);
-
-void hs_TopoDS_Shape_SetChecked(TopoDS_Shape * shape, bool b);
+void hs_TopoDS_Shape_SetModified(TopoDS_Shape * shape, bool b, HSExceptionType* exType, void ** exPtr);
 
 
-bool hs_TopoDS_Shape_Orientable(TopoDS_Shape * shape);
+bool hs_TopoDS_Shape_Checked(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr);
 
-void hs_TopoDS_Shape_SetOrientable(TopoDS_Shape * shape, bool b);
-
-bool hs_TopoDS_Shape_Closed(TopoDS_Shape * shape);
-
-void hs_TopoDS_Shape_SetClosed(TopoDS_Shape * shape, bool b);
+void hs_TopoDS_Shape_SetChecked(TopoDS_Shape * shape, bool b, HSExceptionType* exType, void ** exPtr);
 
 
-bool hs_TopoDS_Shape_Infinite(TopoDS_Shape * shape);
+bool hs_TopoDS_Shape_Orientable(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr);
 
-void hs_TopoDS_Shape_SetInfinite(TopoDS_Shape * shape, bool b);
+void hs_TopoDS_Shape_SetOrientable(TopoDS_Shape * shape, bool b, HSExceptionType* exType, void ** exPtr);
+
+bool hs_TopoDS_Shape_Closed(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr);
+
+void hs_TopoDS_Shape_SetClosed(TopoDS_Shape * shape, bool b, HSExceptionType* exType, void ** exPtr);
 
 
-bool hs_TopoDS_Shape_Convex(TopoDS_Shape * shape);
+bool hs_TopoDS_Shape_Infinite(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr);
 
-void hs_TopoDS_Shape_SetConvex(TopoDS_Shape * shape, bool b);
+void hs_TopoDS_Shape_SetInfinite(TopoDS_Shape * shape, bool b, HSExceptionType* exType, void ** exPtr);
 
-void hs_TopoDS_Shape_Move(TopoDS_Shape * shape, TopLoc_Location * position);
 
-TopoDS_Shape * hs_TopoDS_Shape_Moved(TopoDS_Shape * shape, TopLoc_Location * position);
+bool hs_TopoDS_Shape_Convex(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr);
 
-int hs_TopoDS_Shape_NbChildren(TopoDS_Shape * shape);
+void hs_TopoDS_Shape_SetConvex(TopoDS_Shape * shape, bool b, HSExceptionType* exType, void ** exPtr);
 
-void hs_TopoDS_Shape_Reverse(TopoDS_Shape * shape);
+void hs_TopoDS_Shape_Move(TopoDS_Shape * shape, TopLoc_Location * position, HSExceptionType* exType, void ** exPtr);
 
-TopoDS_Shape * hs_TopoDS_Shape_Reversed(TopoDS_Shape * shape);
+TopoDS_Shape * hs_TopoDS_Shape_Moved(TopoDS_Shape * shape, TopLoc_Location * position, HSExceptionType* exType, void ** exPtr);
 
-void hs_TopoDS_Shape_Complement(TopoDS_Shape * shape);
+int hs_TopoDS_Shape_NbChildren(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr);
 
-TopoDS_Shape * hs_TopoDS_Shape_Complemented(TopoDS_Shape * shape);
+void hs_TopoDS_Shape_Reverse(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr);
 
-void hs_TopoDS_Shape_Compose(TopoDS_Shape * shape, TopAbs_Orientation orient);
+TopoDS_Shape * hs_TopoDS_Shape_Reversed(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr);
 
-TopoDS_Shape * hs_TopoDS_Shape_Composed(TopoDS_Shape * shape, TopAbs_Orientation orient);
+void hs_TopoDS_Shape_Complement(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr);
 
-bool hs_TopoDS_Shape_IsEqual(TopoDS_Shape * a, TopoDS_Shape* b);
+TopoDS_Shape * hs_TopoDS_Shape_Complemented(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr);
 
-bool hs_TopoDS_Shape_IsSame(TopoDS_Shape * a, TopoDS_Shape* b);
+void hs_TopoDS_Shape_Compose(TopoDS_Shape * shape, TopAbs_Orientation orient, HSExceptionType* exType, void ** exPtr);
 
-bool hs_TopoDS_Shape_IsPartner(TopoDS_Shape * a, TopoDS_Shape* b);
+TopoDS_Shape * hs_TopoDS_Shape_Composed(TopoDS_Shape * shape, TopAbs_Orientation orient, HSExceptionType* exType, void ** exPtr);
 
-bool hs_TopoDS_Shape_IsNotEqual(TopoDS_Shape * a, TopoDS_Shape* b);
+bool hs_TopoDS_Shape_IsEqual(TopoDS_Shape * a, TopoDS_Shape* b, HSExceptionType* exType, void ** exPtr);
 
-void hs_TopoDS_Shape_EmptyCopy(TopoDS_Shape * shape);
+bool hs_TopoDS_Shape_IsSame(TopoDS_Shape * a, TopoDS_Shape* b, HSExceptionType* exType, void ** exPtr);
 
-TopoDS_Shape * hs_TopoDS_Shape_EmptyCopied(TopoDS_Shape * shape);
+bool hs_TopoDS_Shape_IsPartner(TopoDS_Shape * a, TopoDS_Shape* b, HSExceptionType* exType, void ** exPtr);
+
+bool hs_TopoDS_Shape_IsNotEqual(TopoDS_Shape * a, TopoDS_Shape* b, HSExceptionType* exType, void ** exPtr);
+
+void hs_TopoDS_Shape_EmptyCopy(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr);
+
+TopoDS_Shape * hs_TopoDS_Shape_EmptyCopied(TopoDS_Shape * shape, HSExceptionType* exType, void ** exPtr);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_XCAFDoc_DocumentTool.cpp
+++ b/opencascade-hs/cpp/hs_XCAFDoc_DocumentTool.cpp
@@ -1,6 +1,12 @@
 #include <XCAFDoc_DocumentTool.hxx>
+#include "hs_Exception.h"
 #include "hs_XCAFDoc_DocumentTool.h"
 
-Handle (XCAFDoc_ShapeTool) * hs_XCAFDoc_DocumentTool_shapeTool(TDF_Label * label){
-    return new opencascade::handle<XCAFDoc_ShapeTool>(XCAFDoc_DocumentTool::ShapeTool(*label));
+Handle (XCAFDoc_ShapeTool) * hs_XCAFDoc_DocumentTool_shapeTool(
+        TDF_Label * label,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(exType, exPtr, [label]{
+        return new opencascade::handle<XCAFDoc_ShapeTool>(XCAFDoc_DocumentTool::ShapeTool(*label));
+    });
 }

--- a/opencascade-hs/cpp/hs_XCAFDoc_DocumentTool.h
+++ b/opencascade-hs/cpp/hs_XCAFDoc_DocumentTool.h
@@ -7,7 +7,10 @@
 extern "C" {
 #endif
 
-Handle (XCAFDoc_ShapeTool) * hs_XCAFDoc_DocumentTool_shapeTool(TDF_Label * label);
+Handle (XCAFDoc_ShapeTool) * hs_XCAFDoc_DocumentTool_shapeTool(
+    TDF_Label * label,
+    HSExceptionType* exType, void ** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_XCAFDoc_ShapeTool.cpp
+++ b/opencascade-hs/cpp/hs_XCAFDoc_ShapeTool.cpp
@@ -1,10 +1,16 @@
 #include <XCAFDoc_ShapeTool.hxx>
+#include "hs_Exception.h"
 #include "hs_XCAFDoc_ShapeTool.h"
 
 void hs_delete_XCAFDoc_ShapeTool(Handle(XCAFDoc_ShapeTool) * shapeTool){
     delete shapeTool;
 }
 
-TDF_Label * hs_XCAFDoc_ShapeTool_addShape(Handle(XCAFDoc_ShapeTool) *shapeTool, TopoDS_Shape *theShape, bool makeAssembly, bool makePrepare){
-    return new TDF_Label(shapeTool->get()->AddShape(*theShape, makeAssembly, makePrepare));
+TDF_Label * hs_XCAFDoc_ShapeTool_addShape(
+        Handle(XCAFDoc_ShapeTool) *shapeTool, TopoDS_Shape *theShape, bool makeAssembly, bool makePrepare,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(exType, exPtr, [shapeTool, theShape, makeAssembly, makePrepare]{
+        return new TDF_Label(shapeTool->get()->AddShape(*theShape, makeAssembly, makePrepare));
+    });
 }

--- a/opencascade-hs/cpp/hs_XCAFDoc_ShapeTool.h
+++ b/opencascade-hs/cpp/hs_XCAFDoc_ShapeTool.h
@@ -9,7 +9,10 @@ extern "C" {
 
 void hs_delete_XCAFDoc_ShapeTool(Handle(XCAFDoc_ShapeTool) * shapeTool);
 
-TDF_Label * hs_XCAFDoc_ShapeTool_addShape(Handle(XCAFDoc_ShapeTool) *shapeTool, TopoDS_Shape *theShape, bool makeAssembly, bool makePrepare);
+TDF_Label * hs_XCAFDoc_ShapeTool_addShape(
+    Handle(XCAFDoc_ShapeTool) *shapeTool, TopoDS_Shape *theShape, bool makeAssembly, bool makePrepare,
+    HSExceptionType* exType, void ** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_XSControl_Reader.cpp
+++ b/opencascade-hs/cpp/hs_XSControl_Reader.cpp
@@ -1,14 +1,45 @@
 #include <XSControl_Reader.hxx>
+#include "hs_Exception.h"
 #include "hs_XSControl_Reader.h"
 
-IFSelect_ReturnStatus hs_XSControl_Reader_readFile(XSControl_Reader * reader, char * filename){
-    return reader->ReadFile(filename);
+IFSelect_ReturnStatus hs_XSControl_Reader_readFile(
+    XSControl_Reader * reader, char * filename,
+    HSExceptionType* exType, void ** exPtr
+    ){
+    return hs_handleExWithDefault(
+        exType,
+        exPtr,
+        [reader, filename]{
+            return reader->ReadFile(filename);
+        },
+        IFSelect_RetError
+    );
 }
 
-bool hs_XSControl_Reader_transferRoots(XSControl_Reader * reader){
-    return reader->TransferRoots();
+bool hs_XSControl_Reader_transferRoots(
+    XSControl_Reader * reader,
+    HSExceptionType* exType, void ** exPtr
+    ){
+        
+    return hs_handleExWithDefault(
+        exType,
+        exPtr,
+        [reader]{
+            return reader->TransferRoots();
+        },
+        false
+    );
 }
 
-TopoDS_Shape * hs_XSControl_Reader_oneShape(XSControl_Reader * reader){
-    return new TopoDS_Shape(reader->OneShape());
+TopoDS_Shape * hs_XSControl_Reader_oneShape(
+    XSControl_Reader * reader,
+    HSExceptionType* exType, void ** exPtr
+    ){
+    return hs_handleEx(
+        exType,
+        exPtr,
+        [reader]{
+            return new TopoDS_Shape(reader->OneShape());
+        }
+    );
 }

--- a/opencascade-hs/cpp/hs_XSControl_Reader.h
+++ b/opencascade-hs/cpp/hs_XSControl_Reader.h
@@ -7,11 +7,20 @@
 extern "C" {
 #endif
 
-IFSelect_ReturnStatus hs_XSControl_Reader_readFile(XSControl_Reader * reader, char * filename);
+IFSelect_ReturnStatus hs_XSControl_Reader_readFile(
+    XSControl_Reader * reader, char * filename,
+    HSExceptionType* exType, void ** exPtr
+);
 
-bool hs_XSControl_Reader_transferRoots(XSControl_Reader * reader);
+bool hs_XSControl_Reader_transferRoots(
+    XSControl_Reader * reader,
+    HSExceptionType* exType, void ** exPtr
+);
 
-TopoDS_Shape * hs_XSControl_Reader_oneShape(XSControl_Reader * reader);
+TopoDS_Shape * hs_XSControl_Reader_oneShape(
+    XSControl_Reader * reader,
+    HSExceptionType* exType, void ** exPtr
+);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_gp_Ax2.cpp
+++ b/opencascade-hs/cpp/hs_gp_Ax2.cpp
@@ -1,8 +1,14 @@
 #include <gp_Ax2.hxx>
+#include "hs_Exception.h"
 #include "hs_gp_Ax2.h"
 
-gp_Ax2 * hs_new_gp_Ax2(gp_Pnt * origin, gp_Dir * north, gp_Dir * vX){
-    return new gp_Ax2(*origin, *north, *vX);
+gp_Ax2 * hs_new_gp_Ax2(
+        gp_Pnt * origin, gp_Dir * north, gp_Dir * vX,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(exType, exPtr, [origin, north, vX]{
+        return new gp_Ax2(*origin, *north, *vX);
+    });
 }
 
 void hs_delete_gp_Ax2(gp_Ax2* ax2){
@@ -33,24 +39,32 @@ gp_Ax1 * hs_gp_Ax2_Axis(gp_Ax2* ax2){
     return new gp_Ax1(ax2->Axis());
 }
 
-void hs_gp_Ax2_SetDirection(gp_Ax2* ax2, gp_Dir* direction){
-    ax2->SetDirection(*direction);
+void hs_gp_Ax2_SetDirection(gp_Ax2* ax2, gp_Dir* direction, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [ax2, direction]{
+        ax2->SetDirection(*direction);
+    });
 }
 
 void hs_gp_Ax2_SetLocation(gp_Ax2* ax2, gp_Pnt* origin){
     ax2->SetLocation(*origin);
 }
 
-void hs_gp_Ax2_SetXDirection(gp_Ax2* ax2, gp_Dir* direction){
-    ax2->SetXDirection(*direction);
+void hs_gp_Ax2_SetXDirection(gp_Ax2* ax2, gp_Dir* direction, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [ax2, direction]{
+        ax2->SetXDirection(*direction);
+    });
 }
 
-void hs_gp_Ax2_SetYDirection(gp_Ax2* ax2, gp_Dir* direction){
-    ax2->SetYDirection(*direction);
+void hs_gp_Ax2_SetYDirection(gp_Ax2* ax2, gp_Dir* direction, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [ax2, direction]{
+        ax2->SetYDirection(*direction);
+    });
 }
 
-void hs_gp_Ax2_SetAxis(gp_Ax2* ax2, gp_Ax1* ax1){
-    ax2->SetAxis(*ax1);
+void hs_gp_Ax2_SetAxis(gp_Ax2* ax2, gp_Ax1* ax1, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [ax2, ax1]{
+        ax2->SetAxis(*ax1);
+    });
 }
 
 bool hs_gp_Ax2_IsCoplanar(gp_Ax2* axis1, gp_Ax2* axis2, double linearTolerance, double angularTolerance){

--- a/opencascade-hs/cpp/hs_gp_Ax2.h
+++ b/opencascade-hs/cpp/hs_gp_Ax2.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-gp_Ax2 * hs_new_gp_Ax2(gp_Pnt * origin, gp_Dir * north, gp_Dir * vX);
+gp_Ax2 * hs_new_gp_Ax2(gp_Pnt * origin, gp_Dir * north, gp_Dir * vX, HSExceptionType* exType, void ** exPtr);
 
 void hs_delete_gp_Ax2(gp_Ax2* ax2);
 
@@ -23,15 +23,15 @@ gp_Dir * hs_gp_Ax2_YDirection(gp_Ax2* ax2);
 
 gp_Ax1 * hs_gp_Ax2_Axis(gp_Ax2* ax2);
 
-void hs_gp_Ax2_SetDirection(gp_Ax2* ax2, gp_Dir* direction);
+void hs_gp_Ax2_SetDirection(gp_Ax2* ax2, gp_Dir* direction, HSExceptionType* exType, void ** exPtr);
 
 void hs_gp_Ax2_SetLocation(gp_Ax2* ax2, gp_Pnt* origin);
 
-void hs_gp_Ax2_SetXDirection(gp_Ax2* ax2, gp_Dir* direction);
+void hs_gp_Ax2_SetXDirection(gp_Ax2* ax2, gp_Dir* direction, HSExceptionType* exType, void ** exPtr);
 
-void hs_gp_Ax2_SetYDirection(gp_Ax2* ax2, gp_Dir* direction);
+void hs_gp_Ax2_SetYDirection(gp_Ax2* ax2, gp_Dir* direction, HSExceptionType* exType, void ** exPtr);
 
-void hs_gp_Ax2_SetAxis(gp_Ax2* ax2, gp_Ax1* ax1);
+void hs_gp_Ax2_SetAxis(gp_Ax2* ax2, gp_Ax1* ax1, HSExceptionType* exType, void ** exPtr);
 
 bool hs_gp_Ax2_IsCoplanar(gp_Ax2* axis1, gp_Ax2* axis2, double linearTolerance, double angularTolerance);
 

--- a/opencascade-hs/cpp/hs_gp_Ax3.cpp
+++ b/opencascade-hs/cpp/hs_gp_Ax3.cpp
@@ -1,4 +1,5 @@
 #include <gp_Ax3.hxx>
+#include "hs_Exception.h"
 #include "hs_gp_Ax3.h"
 
 
@@ -11,8 +12,13 @@ gp_Ax3 * hs_new_gp_Ax3_fromAx2(gp_Ax2 * ax){
 }
 
 
-gp_Ax3 * hs_new_gp_Ax3_fromPntDirAndDir(gp_Pnt * pnt, gp_Dir *n, gp_Dir *v){
-    return new gp_Ax3(*pnt, *n, *v);
+gp_Ax3 * hs_new_gp_Ax3_fromPntDirAndDir(
+        gp_Pnt * pnt, gp_Dir *n, gp_Dir *v,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(exType, exPtr, [pnt, n, v]{
+        return new gp_Ax3(*pnt, *n, *v);
+    });
 }
 
 gp_Ax3 * hs_new_gp_Ax3_fromPntAndDir(gp_Pnt * pnt, gp_Dir *n){
@@ -35,24 +41,32 @@ void hs_gp_Ax3_zReverse(gp_Ax3 * axis){
     axis->ZReverse();
 }
 
-void hs_gp_Ax3_setAxis(gp_Ax3 * axis, gp_Ax1 * mainAxis){
-    axis->SetAxis(*mainAxis);
+void hs_gp_Ax3_setAxis(gp_Ax3 * axis, gp_Ax1 * mainAxis, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [axis, mainAxis]{
+        axis->SetAxis(*mainAxis);
+    });
 }
 
-void hs_gp_Ax3_setDirection(gp_Ax3 * axis, gp_Dir * dir){
-    axis->SetDirection(*dir);
+void hs_gp_Ax3_setDirection(gp_Ax3 * axis, gp_Dir * dir, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [axis, dir]{
+        axis->SetDirection(*dir);
+    });
 }
 
 void hs_gp_Ax3_setLocation(gp_Ax3 * axis, gp_Pnt * loc){
     axis->SetLocation(*loc);
 }
 
-void hs_gp_Ax3_setXDirection(gp_Ax3 * axis, gp_Dir * dir){
-    axis->SetXDirection(*dir);
+void hs_gp_Ax3_setXDirection(gp_Ax3 * axis, gp_Dir * dir, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [axis, dir]{
+        axis->SetXDirection(*dir);
+    });
 }
 
-void hs_gp_Ax3_setYDirection(gp_Ax3 * axis, gp_Dir * dir){
-    axis->SetYDirection(*dir);
+void hs_gp_Ax3_setYDirection(gp_Ax3 * axis, gp_Dir * dir, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [axis, dir]{
+        axis->SetYDirection(*dir);
+    });
 }
 
 double hs_gp_Ax3_angle(gp_Ax3 *axis, gp_Ax3 * other){

--- a/opencascade-hs/cpp/hs_gp_Ax3.h
+++ b/opencascade-hs/cpp/hs_gp_Ax3.h
@@ -11,7 +11,7 @@ gp_Ax3 * hs_new_gp_Ax3();
 
 gp_Ax3 * hs_new_gp_Ax3_fromAx2(gp_Ax2 * ax);
 
-gp_Ax3 * hs_new_gp_Ax3_fromPntDirAndDir(gp_Pnt * pnt, gp_Dir *n, gp_Dir *v);
+gp_Ax3 * hs_new_gp_Ax3_fromPntDirAndDir(gp_Pnt * pnt, gp_Dir *n, gp_Dir *v, HSExceptionType* exType, void ** exPtr);
 
 gp_Ax3 * hs_new_gp_Ax3_fromPntAndDir(gp_Pnt * pnt, gp_Dir *n);
 
@@ -23,15 +23,15 @@ void hs_gp_Ax3_yReverse(gp_Ax3 * axis);
 
 void hs_gp_Ax3_zReverse(gp_Ax3 * axis);
 
-void hs_gp_Ax3_setAxis(gp_Ax3 * axis, gp_Ax1 * mainAxis);
+void hs_gp_Ax3_setAxis(gp_Ax3 * axis, gp_Ax1 * mainAxis, HSExceptionType* exType, void ** exPtr);
 
-void hs_gp_Ax3_setDirection(gp_Ax3 * axis, gp_Dir * dir);
+void hs_gp_Ax3_setDirection(gp_Ax3 * axis, gp_Dir * dir, HSExceptionType* exType, void ** exPtr);
 
 void hs_gp_Ax3_setLocation(gp_Ax3 * axis, gp_Pnt * loc);
 
-void hs_gp_Ax3_setXDirection(gp_Ax3 * axis, gp_Dir * dir);
+void hs_gp_Ax3_setXDirection(gp_Ax3 * axis, gp_Dir * dir, HSExceptionType* exType, void ** exPtr);
 
-void hs_gp_Ax3_setYDirection(gp_Ax3 * axis, gp_Dir * dir);
+void hs_gp_Ax3_setYDirection(gp_Ax3 * axis, gp_Dir * dir, HSExceptionType* exType, void ** exPtr);
 
 double hs_gp_Ax3_angle(gp_Ax3 *axis, gp_Ax3 *other);
 

--- a/opencascade-hs/cpp/hs_gp_Dir.cpp
+++ b/opencascade-hs/cpp/hs_gp_Dir.cpp
@@ -1,8 +1,14 @@
 #include <gp_Dir.hxx>
+#include "hs_Exception.h"
 #include "hs_gp_Dir.h"
 
-gp_Dir * hs_new_gp_Dir(double x, double y, double z) {
-    return new gp_Dir(x, y, z);
+gp_Dir * hs_new_gp_Dir(
+        double x, double y, double z,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(exType, exPtr, [x, y, z]{
+        return new gp_Dir(x, y, z);
+    });
 }
 
 void hs_delete_gp_Dir(gp_Dir* dir){
@@ -53,24 +59,49 @@ double hs_gp_Dir_Angle(gp_Dir * a, gp_Dir * b){
     return a->Angle(*b);
 }
 
-double hs_gp_Dir_AngleWithRef(gp_Dir * a, gp_Dir * b, gp_Dir* theVRef){
-    return a->AngleWithRef(*b, *theVRef);
+double hs_gp_Dir_AngleWithRef(
+        gp_Dir * a, gp_Dir * b, gp_Dir* theVRef,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleExWithDefault(exType, exPtr, [a, b, theVRef]{
+        return a->AngleWithRef(*b, *theVRef);
+    }, 0.0);
 }
 
-void hs_gp_Dir_Cross(gp_Dir * a, gp_Dir * b){
-    a->Cross(*b);
+void hs_gp_Dir_Cross(
+        gp_Dir * a, gp_Dir * b,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(exType, exPtr, [a, b]{
+        a->Cross(*b);
+    });
 }
 
-gp_Dir * hs_gp_Dir_Crossed(gp_Dir * a, gp_Dir * b){
-    return new gp_Dir(a->Crossed(*b));
+gp_Dir * hs_gp_Dir_Crossed(
+        gp_Dir * a, gp_Dir * b,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(exType, exPtr, [a, b]{
+        return new gp_Dir(a->Crossed(*b));
+    });
 }
 
-void hs_gp_Dir_CrossCross(gp_Dir * a, gp_Dir * b, gp_Dir * c){
-    return a->CrossCross(*b, *c);
+void hs_gp_Dir_CrossCross(
+        gp_Dir * a, gp_Dir * b, gp_Dir * c,
+        HSExceptionType* exType, void ** exPtr
+){
+    hs_handleExVoid(exType, exPtr, [a, b, c]{
+        a->CrossCross(*b, *c);
+    });
 }
 
-gp_Dir * hs_gp_Dir_CrossCrossed(gp_Dir * a, gp_Dir * b, gp_Dir * c){
-    return new gp_Dir(a->CrossCrossed(*b, *c));
+gp_Dir * hs_gp_Dir_CrossCrossed(
+        gp_Dir * a, gp_Dir * b, gp_Dir * c,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(exType, exPtr, [a, b, c]{
+        return new gp_Dir(a->CrossCrossed(*b, *c));
+    });
 }
 
 double hs_gp_Dir_Dot(gp_Dir * a, gp_Dir * b){

--- a/opencascade-hs/cpp/hs_gp_Dir.h
+++ b/opencascade-hs/cpp/hs_gp_Dir.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-gp_Dir * hs_new_gp_Dir(double x, double y, double z);
+gp_Dir * hs_new_gp_Dir(double x, double y, double z, HSExceptionType* exType, void ** exPtr);
 
 void hs_delete_gp_Dir(gp_Dir* dir);
 
@@ -33,15 +33,15 @@ bool hs_gp_Dir_IsParallel(gp_Dir * a, gp_Dir * b, double angularTolerance);
 
 double hs_gp_Dir_Angle(gp_Dir * a, gp_Dir * b);
 
-double hs_gp_Dir_AngleWithRef(gp_Dir * a, gp_Dir * b, gp_Dir* theVRef);
+double hs_gp_Dir_AngleWithRef(gp_Dir * a, gp_Dir * b, gp_Dir* theVRef, HSExceptionType* exType, void ** exPtr);
 
-void hs_gp_Dir_Cross(gp_Dir * a, gp_Dir * b);
+void hs_gp_Dir_Cross(gp_Dir * a, gp_Dir * b, HSExceptionType* exType, void ** exPtr);
 
-gp_Dir * hs_gp_Dir_Crossed(gp_Dir * a, gp_Dir * b);
+gp_Dir * hs_gp_Dir_Crossed(gp_Dir * a, gp_Dir * b, HSExceptionType* exType, void ** exPtr);
 
-void hs_gp_Dir_CrossCross(gp_Dir * a, gp_Dir * b, gp_Dir * c);
+void hs_gp_Dir_CrossCross(gp_Dir * a, gp_Dir * b, gp_Dir * c, HSExceptionType* exType, void ** exPtr);
 
-gp_Dir * hs_gp_Dir_CrossCrossed(gp_Dir * a, gp_Dir * b, gp_Dir * c);
+gp_Dir * hs_gp_Dir_CrossCrossed(gp_Dir * a, gp_Dir * b, gp_Dir * c, HSExceptionType* exType, void ** exPtr);
 
 double hs_gp_Dir_Dot(gp_Dir * a, gp_Dir * b);
 

--- a/opencascade-hs/cpp/hs_gp_Dir2d.cpp
+++ b/opencascade-hs/cpp/hs_gp_Dir2d.cpp
@@ -1,8 +1,14 @@
 #include <gp_Dir2d.hxx>
+#include "hs_Exception.h"
 #include "hs_gp_Dir2d.h"
 
-gp_Dir2d * hs_new_gp_Dir2d(double x, double y) {
-    return new gp_Dir2d(x, y);
+gp_Dir2d * hs_new_gp_Dir2d(
+        double x, double y,
+        HSExceptionType* exType, void ** exPtr
+){
+    return hs_handleEx(exType, exPtr, [x, y]{
+        return new gp_Dir2d(x, y);
+    });
 }
 
 void hs_delete_gp_Dir2d(gp_Dir2d* dir){

--- a/opencascade-hs/cpp/hs_gp_Dir2d.h
+++ b/opencascade-hs/cpp/hs_gp_Dir2d.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-gp_Dir2d * hs_new_gp_Dir2d(double x, double y);
+gp_Dir2d * hs_new_gp_Dir2d(double x, double y, HSExceptionType* exType, void ** exPtr);
 
 void hs_delete_gp_Dir2d(gp_Dir2d* dir);
 

--- a/opencascade-hs/cpp/hs_gp_GTrsf.cpp
+++ b/opencascade-hs/cpp/hs_gp_GTrsf.cpp
@@ -1,4 +1,5 @@
 #include <gp_GTrsf.hxx>
+#include "hs_Exception.h"
 #include "hs_gp_GTrsf.h"
 
 gp_GTrsf * hs_new_gp_GTrsf(){
@@ -9,11 +10,15 @@ void hs_delete_gp_GTrsf(gp_GTrsf * t){
     delete t;
 }
 
-void hs_gp_GTrsf_setValue(gp_GTrsf * trsf, int row, int col, double value){
-    trsf->SetValue(row, col, value);
+void hs_gp_GTrsf_setValue(gp_GTrsf * trsf, int row, int col, double value, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [trsf, row, col, value]{
+        trsf->SetValue(row, col, value);
+    });
 }
 
 
-void hs_gp_GTrsf_setForm(gp_GTrsf * trsf){
-    trsf->SetForm();
+void hs_gp_GTrsf_setForm(gp_GTrsf * trsf, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [trsf]{
+        trsf->SetForm();
+    });
 }

--- a/opencascade-hs/cpp/hs_gp_GTrsf.h
+++ b/opencascade-hs/cpp/hs_gp_GTrsf.h
@@ -12,9 +12,9 @@ gp_GTrsf * hs_new_gp_GTrsf();
 
 void hs_delete_gp_GTrsf(gp_GTrsf * t);
 
-void hs_gp_GTrsf_setValue(gp_GTrsf * trsf, int row, int col, double value);
+void hs_gp_GTrsf_setValue(gp_GTrsf * trsf, int row, int col, double value, HSExceptionType* exType, void ** exPtr);
 
-void hs_gp_GTrsf_setForm(gp_GTrsf * trsf);
+void hs_gp_GTrsf_setForm(gp_GTrsf * trsf, HSExceptionType* exType, void ** exPtr);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_gp_Trsf.cpp
+++ b/opencascade-hs/cpp/hs_gp_Trsf.cpp
@@ -1,4 +1,5 @@
 #include <gp_Trsf.hxx>
+#include "hs_Exception.h"
 #include "hs_gp_Trsf.h"
 
 gp_Trsf * hs_new_gp_Trsf(){
@@ -29,8 +30,10 @@ void hs_gp_Trsf_SetRotationAboutAxisAngle(gp_Trsf * trsf, gp_Ax1 * ax, double an
     trsf->SetRotation(*ax, angle);
 }
 
-void hs_gp_Trsf_SetScale(gp_Trsf * trsf, gp_Pnt * origin, double factor){
-    trsf->SetScale(*origin, factor);
+void hs_gp_Trsf_SetScale(gp_Trsf * trsf, gp_Pnt * origin, double factor, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [trsf, origin, factor]{
+        trsf->SetScale(*origin, factor);
+    });
 }
 
 void hs_gp_Trsf_SetTranslation(gp_Trsf * trsf, gp_Vec * trans){
@@ -41,23 +44,28 @@ void hs_gp_Trsf_SetTranslationPart(gp_Trsf * trsf, gp_Vec * trans){
     trsf->SetTranslationPart(*trans);
 }
 
-void hs_gp_Trsf_SetScaleFactor(gp_Trsf * trsf, double s){
-    trsf->SetScaleFactor(s);
+void hs_gp_Trsf_SetScaleFactor(gp_Trsf * trsf, double s, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [trsf, s]{
+        trsf->SetScaleFactor(s);
+    });
 }
 
 void hs_gp_Trsf_SetDisplacement(gp_Trsf * trsf, gp_Ax3 *from, gp_Ax3 * to){
     trsf->SetDisplacement(*from, *to);
 }
 
-void hs_gp_Trsf_SetValues(gp_Trsf * trsf, 
+void hs_gp_Trsf_SetValues(gp_Trsf * trsf,
         double a11, double a12, double a13, double a14,
         double a21, double a22, double a23, double a24,
-        double a31, double a32, double a33, double a34){
-    trsf->SetValues(
-         a11, a12, a13, a14,
-         a21, a22, a23, a24,
-         a31, a32, a33, a34
-    );
+        double a31, double a32, double a33, double a34,
+        HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [=]{
+        trsf->SetValues(
+             a11, a12, a13, a14,
+             a21, a22, a23, a24,
+             a31, a32, a33, a34
+        );
+    });
 }
 
 bool hs_gp_Trsf_IsNegative(gp_Trsf * trsf){
@@ -68,16 +76,22 @@ double hs_gp_Trsf_ScaleFactor(gp_Trsf * trsf){
     return trsf->ScaleFactor();
 }
 
-double hs_gp_Trsf_Value(gp_Trsf* trsf, int row, int col){
-    return trsf->Value(row, col);
+double hs_gp_Trsf_Value(gp_Trsf* trsf, int row, int col, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(exType, exPtr, [trsf, row, col]{
+        return trsf->Value(row, col);
+    }, 0.0);
 }
 
-void hs_gp_Trsf_Invert(gp_Trsf* trsf){
-    trsf->Invert();
+void hs_gp_Trsf_Invert(gp_Trsf* trsf, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [trsf]{
+        trsf->Invert();
+    });
 }
 
-gp_Trsf * hs_gp_Trsf_Inverted(gp_Trsf* trsf){
-    return new gp_Trsf(trsf->Inverted());
+gp_Trsf * hs_gp_Trsf_Inverted(gp_Trsf* trsf, HSExceptionType* exType, void ** exPtr){
+    return hs_handleEx(exType, exPtr, [trsf]{
+        return new gp_Trsf(trsf->Inverted());
+    });
 }
 
 void hs_gp_Trsf_Multiply(gp_Trsf * trsf, gp_Trsf* b){
@@ -92,11 +106,15 @@ void hs_gp_Trsf_PreMultiply(gp_Trsf * trsf, gp_Trsf* b){
     trsf->PreMultiply(*b);
 }
 
-void hs_gp_Trsf_Power(gp_Trsf * trsf, int b){
-    trsf->Power(b);
+void hs_gp_Trsf_Power(gp_Trsf * trsf, int b, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [trsf, b]{
+        trsf->Power(b);
+    });
 }
 
-gp_Trsf * hs_gp_Trsf_Powered(gp_Trsf* a, int b){
-    return new gp_Trsf(a->Powered(b));
+gp_Trsf * hs_gp_Trsf_Powered(gp_Trsf* a, int b, HSExceptionType* exType, void ** exPtr){
+    return hs_handleEx(exType, exPtr, [a, b]{
+        return new gp_Trsf(a->Powered(b));
+    });
 }
 

--- a/opencascade-hs/cpp/hs_gp_Trsf.h
+++ b/opencascade-hs/cpp/hs_gp_Trsf.h
@@ -22,18 +22,19 @@ void hs_gp_Trsf_SetMirrorAboutAx2(gp_Trsf * trsf, gp_Ax2 * ax);
 
 void hs_gp_Trsf_SetRotationAboutAxisAngle(gp_Trsf * trsf, gp_Ax1 * ax, double angle);
 
-void hs_gp_Trsf_SetScale(gp_Trsf * trsf, gp_Pnt * origin, double factor);
+void hs_gp_Trsf_SetScale(gp_Trsf * trsf, gp_Pnt * origin, double factor, HSExceptionType* exType, void ** exPtr);
 
 void hs_gp_Trsf_SetTranslation(gp_Trsf * trsf, gp_Vec * trans);
 
 void hs_gp_Trsf_SetTranslationPart(gp_Trsf * trsf, gp_Vec * trans);
 
-void hs_gp_Trsf_SetScaleFactor(gp_Trsf * trsf, double s);
+void hs_gp_Trsf_SetScaleFactor(gp_Trsf * trsf, double s, HSExceptionType* exType, void ** exPtr);
 
-void hs_gp_Trsf_SetValues(gp_Trsf * trsf, 
+void hs_gp_Trsf_SetValues(gp_Trsf * trsf,
         double a11, double a12, double a13, double a14,
         double a21, double a22, double a23, double a24,
-        double a31, double a32, double a33, double a34);
+        double a31, double a32, double a33, double a34,
+        HSExceptionType* exType, void ** exPtr);
 
 bool hs_gp_Trsf_IsNegative(gp_Trsf * trsf);
 
@@ -41,11 +42,11 @@ double hs_gp_Trsf_ScaleFactor(gp_Trsf * trsf);
 
 void hs_gp_Trsf_SetDisplacement(gp_Trsf * trsf, gp_Ax3 *from, gp_Ax3 * to);
 
-double hs_gp_Trsf_Value(gp_Trsf* trsf, int row, int col);
+double hs_gp_Trsf_Value(gp_Trsf* trsf, int row, int col, HSExceptionType* exType, void ** exPtr);
 
-void hs_gp_Trsf_Invert(gp_Trsf* trsf);
+void hs_gp_Trsf_Invert(gp_Trsf* trsf, HSExceptionType* exType, void ** exPtr);
 
-gp_Trsf * hs_gp_Trsf_Inverted(gp_Trsf* trsf);
+gp_Trsf * hs_gp_Trsf_Inverted(gp_Trsf* trsf, HSExceptionType* exType, void ** exPtr);
 
 void hs_gp_Trsf_Multiply(gp_Trsf * trsf, gp_Trsf* b);
 
@@ -53,9 +54,9 @@ gp_Trsf * hs_gp_Trsf_Multiplied(gp_Trsf* a, gp_Trsf* b);
 
 void hs_gp_Trsf_PreMultiply(gp_Trsf * trsf, gp_Trsf* b);
 
-void hs_gp_Trsf_Power(gp_Trsf * trsf, int b);
+void hs_gp_Trsf_Power(gp_Trsf * trsf, int b, HSExceptionType* exType, void ** exPtr);
 
-gp_Trsf * hs_gp_Trsf_Powered(gp_Trsf* a, int b);
+gp_Trsf * hs_gp_Trsf_Powered(gp_Trsf* a, int b, HSExceptionType* exType, void ** exPtr);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_gp_Trsf2d.cpp
+++ b/opencascade-hs/cpp/hs_gp_Trsf2d.cpp
@@ -1,4 +1,5 @@
 #include <gp_Trsf2d.hxx>
+#include "hs_Exception.h"
 #include "hs_gp_Trsf2d.h"
 
 gp_Trsf2d * hs_new_gp_Trsf2d(){
@@ -25,8 +26,10 @@ void hs_gp_Trsf2d_SetRotation(gp_Trsf2d * trsf, gp_Pnt2d * ax, double angle){
     trsf->SetRotation(*ax, angle);
 }
 
-void hs_gp_Trsf2d_SetScale(gp_Trsf2d * trsf, gp_Pnt2d * origin, double factor){
-    trsf->SetScale(*origin, factor);
+void hs_gp_Trsf2d_SetScale(gp_Trsf2d * trsf, gp_Pnt2d * origin, double factor, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [trsf, origin, factor]{
+        trsf->SetScale(*origin, factor);
+    });
 }
 
 void hs_gp_Trsf2d_SetTransformation(gp_Trsf2d * trsf, gp_Ax2d * to){
@@ -49,17 +52,22 @@ void hs_gp_Trsf2d_SetTranslationPart(gp_Trsf2d * trsf, gp_Vec2d * trans){
     trsf->SetTranslationPart(*trans);
 }
 
-void hs_gp_Trsf2d_SetScaleFactor(gp_Trsf2d * trsf, double s){
-    trsf->SetScaleFactor(s);
+void hs_gp_Trsf2d_SetScaleFactor(gp_Trsf2d * trsf, double s, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [trsf, s]{
+        trsf->SetScaleFactor(s);
+    });
 }
 
-void hs_gp_Trsf2d_SetValues(gp_Trsf2d * trsf, 
-        double a11, double a12, double a13, 
-        double a21, double a22, double a23){
-    trsf->SetValues(
-         a11, a12, a13,
-         a21, a22, a23
-    );
+void hs_gp_Trsf2d_SetValues(gp_Trsf2d * trsf,
+        double a11, double a12, double a13,
+        double a21, double a22, double a23,
+        HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [=]{
+        trsf->SetValues(
+             a11, a12, a13,
+             a21, a22, a23
+        );
+    });
 }
 
 bool hs_gp_Trsf2d_IsNegative(gp_Trsf2d * trsf){
@@ -70,16 +78,22 @@ double hs_gp_Trsf2d_ScaleFactor(gp_Trsf2d * trsf){
     return trsf->ScaleFactor();
 }
 
-double hs_gp_Trsf2d_Value(gp_Trsf2d* trsf, int row, int col){
-    return trsf->Value(row, col);
+double hs_gp_Trsf2d_Value(gp_Trsf2d* trsf, int row, int col, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(exType, exPtr, [trsf, row, col]{
+        return trsf->Value(row, col);
+    }, 0.0);
 }
 
-void hs_gp_Trsf2d_Invert(gp_Trsf2d* trsf){
-    trsf->Invert();
+void hs_gp_Trsf2d_Invert(gp_Trsf2d* trsf, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [trsf]{
+        trsf->Invert();
+    });
 }
 
-gp_Trsf2d * hs_gp_Trsf2d_Inverted(gp_Trsf2d* trsf){
-    return new gp_Trsf2d(trsf->Inverted());
+gp_Trsf2d * hs_gp_Trsf2d_Inverted(gp_Trsf2d* trsf, HSExceptionType* exType, void ** exPtr){
+    return hs_handleEx(exType, exPtr, [trsf]{
+        return new gp_Trsf2d(trsf->Inverted());
+    });
 }
 
 void hs_gp_Trsf2d_Multiply(gp_Trsf2d * trsf, gp_Trsf2d* b){
@@ -94,11 +108,15 @@ void hs_gp_Trsf2d_PreMultiply(gp_Trsf2d * trsf, gp_Trsf2d* b){
     trsf->PreMultiply(*b);
 }
 
-void hs_gp_Trsf2d_Power(gp_Trsf2d * trsf, int b){
-    trsf->Power(b);
+void hs_gp_Trsf2d_Power(gp_Trsf2d * trsf, int b, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [trsf, b]{
+        trsf->Power(b);
+    });
 }
 
-gp_Trsf2d * hs_gp_Trsf2d_Powered(gp_Trsf2d* a, int b){
-    return new gp_Trsf2d(a->Powered(b));
+gp_Trsf2d * hs_gp_Trsf2d_Powered(gp_Trsf2d* a, int b, HSExceptionType* exType, void ** exPtr){
+    return hs_handleEx(exType, exPtr, [a, b]{
+        return new gp_Trsf2d(a->Powered(b));
+    });
 }
 

--- a/opencascade-hs/cpp/hs_gp_Trsf2d.h
+++ b/opencascade-hs/cpp/hs_gp_Trsf2d.h
@@ -19,7 +19,7 @@ void hs_gp_Trsf2d_SetMirrorAboutAx2d(gp_Trsf2d * trsf, gp_Ax2d * ax);
 
 void hs_gp_Trsf2d_SetRotation(gp_Trsf2d * trsf, gp_Pnt2d * ax, double angle);
 
-void hs_gp_Trsf2d_SetScale(gp_Trsf2d * trsf, gp_Pnt2d * origin, double factor);
+void hs_gp_Trsf2d_SetScale(gp_Trsf2d * trsf, gp_Pnt2d * origin, double factor, HSExceptionType* exType, void ** exPtr);
 
 void hs_gp_Trsf2d_SetTransformation(gp_Trsf2d * trsf, gp_Ax2d * to);
 
@@ -31,21 +31,22 @@ void hs_gp_Trsf2d_SetTranslationRelative(gp_Trsf2d * trsf, gp_Pnt2d * from, gp_P
 
 void hs_gp_Trsf2d_SetTranslationPart(gp_Trsf2d * trsf, gp_Vec2d * trans);
 
-void hs_gp_Trsf2d_SetScaleFactor(gp_Trsf2d * trsf, double s);
+void hs_gp_Trsf2d_SetScaleFactor(gp_Trsf2d * trsf, double s, HSExceptionType* exType, void ** exPtr);
 
-void hs_gp_Trsf2d_SetValues(gp_Trsf2d * trsf, 
-        double a11, double a12, double a13, 
-        double a21, double a22, double a23);
+void hs_gp_Trsf2d_SetValues(gp_Trsf2d * trsf,
+        double a11, double a12, double a13,
+        double a21, double a22, double a23,
+        HSExceptionType* exType, void ** exPtr);
 
 bool hs_gp_Trsf2d_IsNegative(gp_Trsf2d * trsf);
 
 double hs_gp_Trsf2d_ScaleFactor(gp_Trsf2d * trsf);
 
-double hs_gp_Trsf2d_Value(gp_Trsf2d* trsf, int row, int col);
+double hs_gp_Trsf2d_Value(gp_Trsf2d* trsf, int row, int col, HSExceptionType* exType, void ** exPtr);
 
-void hs_gp_Trsf2d_Invert(gp_Trsf2d* trsf);
+void hs_gp_Trsf2d_Invert(gp_Trsf2d* trsf, HSExceptionType* exType, void ** exPtr);
 
-gp_Trsf2d * hs_gp_Trsf2d_Inverted(gp_Trsf2d* trsf);
+gp_Trsf2d * hs_gp_Trsf2d_Inverted(gp_Trsf2d* trsf, HSExceptionType* exType, void ** exPtr);
 
 void hs_gp_Trsf2d_Multiply(gp_Trsf2d * trsf, gp_Trsf2d* b);
 
@@ -53,9 +54,9 @@ gp_Trsf2d * hs_gp_Trsf2d_Multiplied(gp_Trsf2d* a, gp_Trsf2d* b);
 
 void hs_gp_Trsf2d_PreMultiply(gp_Trsf2d * trsf, gp_Trsf2d* b);
 
-void hs_gp_Trsf2d_Power(gp_Trsf2d * trsf, int b);
+void hs_gp_Trsf2d_Power(gp_Trsf2d * trsf, int b, HSExceptionType* exType, void ** exPtr);
 
-gp_Trsf2d * hs_gp_Trsf2d_Powered(gp_Trsf2d* a, int b);
+gp_Trsf2d * hs_gp_Trsf2d_Powered(gp_Trsf2d* a, int b, HSExceptionType* exType, void ** exPtr);
 
 #ifdef __cplusplus
 }

--- a/opencascade-hs/cpp/hs_gp_Vec.cpp
+++ b/opencascade-hs/cpp/hs_gp_Vec.cpp
@@ -1,4 +1,5 @@
 #include <gp_Vec.hxx>
+#include "hs_Exception.h"
 #include "hs_gp_Vec.h"
 
 gp_Vec * hs_new_gp_Vec(double x, double y, double z) {
@@ -38,24 +39,34 @@ bool hs_gp_Vec_IsEqual(gp_Vec * a, gp_Vec * b, double linearTolerance, double an
     return a->IsEqual(*b, linearTolerance, angularTolerance);
 }
 
-bool hs_gp_Vec_IsNormal(gp_Vec * a, gp_Vec * b, double angularTolerance){
-    return a->IsNormal(*b, angularTolerance);
+bool hs_gp_Vec_IsNormal(gp_Vec * a, gp_Vec * b, double angularTolerance, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(exType, exPtr, [a, b, angularTolerance]{
+        return a->IsNormal(*b, angularTolerance);
+    }, false);
 }
 
-bool hs_gp_Vec_IsOpposite(gp_Vec * a, gp_Vec * b, double angularTolerance){
-    return a->IsOpposite(*b, angularTolerance);
+bool hs_gp_Vec_IsOpposite(gp_Vec * a, gp_Vec * b, double angularTolerance, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(exType, exPtr, [a, b, angularTolerance]{
+        return a->IsOpposite(*b, angularTolerance);
+    }, false);
 }
 
-bool hs_gp_Vec_IsParallel(gp_Vec * a, gp_Vec * b, double angularTolerance){
-    return a->IsParallel(*b, angularTolerance);
+bool hs_gp_Vec_IsParallel(gp_Vec * a, gp_Vec * b, double angularTolerance, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(exType, exPtr, [a, b, angularTolerance]{
+        return a->IsParallel(*b, angularTolerance);
+    }, false);
 }
 
-double hs_gp_Vec_Angle(gp_Vec * a, gp_Vec * b){
-    return a->Angle(*b);
+double hs_gp_Vec_Angle(gp_Vec * a, gp_Vec * b, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(exType, exPtr, [a, b]{
+        return a->Angle(*b);
+    }, 0.0);
 }
 
-double hs_gp_Vec_AngleWithRef(gp_Vec * a, gp_Vec * b, gp_Vec* theVRef){
-    return a->AngleWithRef(*b, *theVRef);
+double hs_gp_Vec_AngleWithRef(gp_Vec * a, gp_Vec * b, gp_Vec* theVRef, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(exType, exPtr, [a, b, theVRef]{
+        return a->AngleWithRef(*b, *theVRef);
+    }, 0.0);
 }
 
 double hs_gp_Vec_Magnitude(gp_Vec * a){
@@ -132,12 +143,16 @@ double hs_gp_Vec_DotCross(gp_Vec * a, gp_Vec * b, gp_Vec * c){
     return a->DotCross(*b, *c);
 }
 
-void hs_gp_Vec_Normalize(gp_Vec * a){
-    a->Normalize();
+void hs_gp_Vec_Normalize(gp_Vec * a, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [a]{
+        a->Normalize();
+    });
 }
 
-gp_Vec * hs_gp_Vec_Normalized(gp_Vec * a){
-    return new gp_Vec(a->Normalized());
+gp_Vec * hs_gp_Vec_Normalized(gp_Vec * a, HSExceptionType* exType, void ** exPtr){
+    return hs_handleEx(exType, exPtr, [a]{
+        return new gp_Vec(a->Normalized());
+    });
 }
 
 void hs_gp_Vec_Reverse(gp_Vec* a){

--- a/opencascade-hs/cpp/hs_gp_Vec.h
+++ b/opencascade-hs/cpp/hs_gp_Vec.h
@@ -25,15 +25,15 @@ void hs_gp_Vec_SetZ(gp_Vec * vec, double z);
 
 bool hs_gp_Vec_IsEqual(gp_Vec * a, gp_Vec * b, double linearTolerance, double angularTolerance);
 
-bool hs_gp_Vec_IsNormal(gp_Vec * a, gp_Vec * b, double angularTolerance);
+bool hs_gp_Vec_IsNormal(gp_Vec * a, gp_Vec * b, double angularTolerance, HSExceptionType* exType, void ** exPtr);
 
-bool hs_gp_Vec_IsOpposite(gp_Vec * a, gp_Vec * b, double angularTolerance);
+bool hs_gp_Vec_IsOpposite(gp_Vec * a, gp_Vec * b, double angularTolerance, HSExceptionType* exType, void ** exPtr);
 
-bool hs_gp_Vec_IsParallel(gp_Vec * a, gp_Vec * b, double angularTolerance);
+bool hs_gp_Vec_IsParallel(gp_Vec * a, gp_Vec * b, double angularTolerance, HSExceptionType* exType, void ** exPtr);
 
-double hs_gp_Vec_Angle(gp_Vec * a, gp_Vec * b);
+double hs_gp_Vec_Angle(gp_Vec * a, gp_Vec * b, HSExceptionType* exType, void ** exPtr);
 
-double hs_gp_Vec_AngleWithRef(gp_Vec * a, gp_Vec * b, gp_Vec* theVRef);
+double hs_gp_Vec_AngleWithRef(gp_Vec * a, gp_Vec * b, gp_Vec* theVRef, HSExceptionType* exType, void ** exPtr);
 
 double hs_gp_Vec_Magnitude(gp_Vec * a);
 
@@ -72,9 +72,9 @@ double hs_gp_Vec_Dot(gp_Vec * a, gp_Vec * b);
 
 double hs_gp_Vec_DotCross(gp_Vec * a, gp_Vec * b, gp_Vec * c);
 
-void hs_gp_Vec_Normalize(gp_Vec * a);
+void hs_gp_Vec_Normalize(gp_Vec * a, HSExceptionType* exType, void ** exPtr);
 
-gp_Vec * hs_gp_Vec_Normalized(gp_Vec * a);
+gp_Vec * hs_gp_Vec_Normalized(gp_Vec * a, HSExceptionType* exType, void ** exPtr);
 
 void hs_gp_Vec_Reverse(gp_Vec* a);
 

--- a/opencascade-hs/cpp/hs_gp_Vec2d.cpp
+++ b/opencascade-hs/cpp/hs_gp_Vec2d.cpp
@@ -1,4 +1,5 @@
 #include <gp_Vec2d.hxx>
+#include "hs_Exception.h"
 #include "hs_gp_Vec2d.h"
 
 gp_Vec2d * hs_new_gp_Vec2d(double x, double y) {
@@ -29,20 +30,28 @@ bool hs_gp_Vec2d_IsEqual(gp_Vec2d * a, gp_Vec2d * b, double linearTolerance, dou
     return a->IsEqual(*b, linearTolerance, angularTolerance);
 }
 
-bool hs_gp_Vec2d_IsNormal(gp_Vec2d * a, gp_Vec2d * b, double angularTolerance){
-    return a->IsNormal(*b, angularTolerance);
+bool hs_gp_Vec2d_IsNormal(gp_Vec2d * a, gp_Vec2d * b, double angularTolerance, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(exType, exPtr, [a, b, angularTolerance]{
+        return a->IsNormal(*b, angularTolerance);
+    }, false);
 }
 
-bool hs_gp_Vec2d_IsOpposite(gp_Vec2d * a, gp_Vec2d * b, double angularTolerance){
-    return a->IsOpposite(*b, angularTolerance);
+bool hs_gp_Vec2d_IsOpposite(gp_Vec2d * a, gp_Vec2d * b, double angularTolerance, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(exType, exPtr, [a, b, angularTolerance]{
+        return a->IsOpposite(*b, angularTolerance);
+    }, false);
 }
 
-bool hs_gp_Vec2d_IsParallel(gp_Vec2d * a, gp_Vec2d * b, double angularTolerance){
-    return a->IsParallel(*b, angularTolerance);
+bool hs_gp_Vec2d_IsParallel(gp_Vec2d * a, gp_Vec2d * b, double angularTolerance, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(exType, exPtr, [a, b, angularTolerance]{
+        return a->IsParallel(*b, angularTolerance);
+    }, false);
 }
 
-double hs_gp_Vec2d_Angle(gp_Vec2d * a, gp_Vec2d * b){
-    return a->Angle(*b);
+double hs_gp_Vec2d_Angle(gp_Vec2d * a, gp_Vec2d * b, HSExceptionType* exType, void ** exPtr){
+    return hs_handleExWithDefault(exType, exPtr, [a, b]{
+        return a->Angle(*b);
+    }, 0.0);
 }
 
 double hs_gp_Vec2d_Magnitude(gp_Vec2d * a){
@@ -102,12 +111,16 @@ double hs_gp_Vec2d_Dot(gp_Vec2d * a, gp_Vec2d * b){
     return a->Dot(*b);
 }
 
-void hs_gp_Vec2d_Normalize(gp_Vec2d * a){
-    a->Normalize();
+void hs_gp_Vec2d_Normalize(gp_Vec2d * a, HSExceptionType* exType, void ** exPtr){
+    hs_handleExVoid(exType, exPtr, [a]{
+        a->Normalize();
+    });
 }
 
-gp_Vec2d * hs_gp_Vec2d_Normalized(gp_Vec2d * a){
-    return new gp_Vec2d(a->Normalized());
+gp_Vec2d * hs_gp_Vec2d_Normalized(gp_Vec2d * a, HSExceptionType* exType, void ** exPtr){
+    return hs_handleEx(exType, exPtr, [a]{
+        return new gp_Vec2d(a->Normalized());
+    });
 }
 
 void hs_gp_Vec2d_Reverse(gp_Vec2d* a){

--- a/opencascade-hs/cpp/hs_gp_Vec2d.h
+++ b/opencascade-hs/cpp/hs_gp_Vec2d.h
@@ -21,13 +21,13 @@ void hs_gp_Vec2d_SetY(gp_Vec2d * vec, double y);
 
 bool hs_gp_Vec2d_IsEqual(gp_Vec2d * a, gp_Vec2d * b, double linearTolerance, double angularTolerance);
 
-bool hs_gp_Vec2d_IsNormal(gp_Vec2d * a, gp_Vec2d * b, double angularTolerance);
+bool hs_gp_Vec2d_IsNormal(gp_Vec2d * a, gp_Vec2d * b, double angularTolerance, HSExceptionType* exType, void ** exPtr);
 
-bool hs_gp_Vec2d_IsOpposite(gp_Vec2d * a, gp_Vec2d * b, double angularTolerance);
+bool hs_gp_Vec2d_IsOpposite(gp_Vec2d * a, gp_Vec2d * b, double angularTolerance, HSExceptionType* exType, void ** exPtr);
 
-bool hs_gp_Vec2d_IsParallel(gp_Vec2d * a, gp_Vec2d * b, double angularTolerance);
+bool hs_gp_Vec2d_IsParallel(gp_Vec2d * a, gp_Vec2d * b, double angularTolerance, HSExceptionType* exType, void ** exPtr);
 
-double hs_gp_Vec2d_Angle(gp_Vec2d * a, gp_Vec2d * b);
+double hs_gp_Vec2d_Angle(gp_Vec2d * a, gp_Vec2d * b, HSExceptionType* exType, void ** exPtr);
 
 double hs_gp_Vec2d_Magnitude(gp_Vec2d * a);
 
@@ -58,9 +58,9 @@ double hs_gp_Vec2d_CrossSquareMagnitude(gp_Vec2d * a, gp_Vec2d * b);
 
 double hs_gp_Vec2d_Dot(gp_Vec2d * a, gp_Vec2d * b);
 
-void hs_gp_Vec2d_Normalize(gp_Vec2d * a);
+void hs_gp_Vec2d_Normalize(gp_Vec2d * a, HSExceptionType* exType, void ** exPtr);
 
-gp_Vec2d * hs_gp_Vec2d_Normalized(gp_Vec2d * a);
+gp_Vec2d * hs_gp_Vec2d_Normalized(gp_Vec2d * a, HSExceptionType* exType, void ** exPtr);
 
 void hs_gp_Vec2d_Reverse(gp_Vec2d* a);
 

--- a/opencascade-hs/cpp/hs_types.h
+++ b/opencascade-hs/cpp/hs_types.h
@@ -106,13 +106,18 @@ typedef void BOPAlgo_Builder;
 typedef void BOPAlgo_BOP;
 typedef int BOPAlgo_Operation;
 typedef void GCPnts_AbscissaPoint;
+typedef void Standard_Failure;
+typedef void STD_EXCEPTION;
 
 typedef int HSExceptionType;
 
 #define Handle(X) void
 #define ARRAY_1(X) void
 #else // __cplusplus
+#include <exception>
+
 #define ARRAY_1(X) NCollection_Array1<X>
+typedef std::exception STD_EXCEPTION;
 #endif // __cplusplus
 #endif // HS_TYPES_H
 

--- a/opencascade-hs/cpp/hs_types.h
+++ b/opencascade-hs/cpp/hs_types.h
@@ -107,6 +107,8 @@ typedef void BOPAlgo_BOP;
 typedef int BOPAlgo_Operation;
 typedef void GCPnts_AbscissaPoint;
 
+typedef int HSExceptionType;
+
 #define Handle(X) void
 #define ARRAY_1(X) void
 #else // __cplusplus

--- a/opencascade-hs/cpp/hs_types.h
+++ b/opencascade-hs/cpp/hs_types.h
@@ -108,6 +108,7 @@ typedef int BOPAlgo_Operation;
 typedef void GCPnts_AbscissaPoint;
 typedef void Standard_Failure;
 typedef void STD_EXCEPTION;
+typedef void STD_RUNTIME_ERROR;
 
 typedef int HSExceptionType;
 
@@ -115,9 +116,11 @@ typedef int HSExceptionType;
 #define ARRAY_1(X) void
 #else // __cplusplus
 #include <exception>
+#include <stdexcept>
 
 #define ARRAY_1(X) NCollection_Array1<X>
 typedef std::exception STD_EXCEPTION;
+typedef std::runtime_error STD_RUNTIME_ERROR;
 #endif // __cplusplus
 #endif // HS_TYPES_H
 

--- a/opencascade-hs/opencascade-hs.cabal
+++ b/opencascade-hs/opencascade-hs.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 
--- This file has been generated from package.yaml by hpack version 0.38.1.
+-- This file has been generated from package.yaml by hpack version 0.39.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -299,6 +299,7 @@ library
       OpenCascade.Standard.Types
       OpenCascade.Std.Exception
       OpenCascade.Std.Internal.Destructors
+      OpenCascade.Std.RuntimeError
       OpenCascade.Std.Types
       OpenCascade.STEPControl
       OpenCascade.STEPControl.Internal.Destructors

--- a/opencascade-hs/opencascade-hs.cabal
+++ b/opencascade-hs/opencascade-hs.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.38.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -58,6 +58,7 @@ extra-source-files:
     cpp/hs_BRepPrimAPI_MakeSphere.h
     cpp/hs_BRepPrimAPI_MakeTorus.h
     cpp/hs_BRepTools_WireExplorer.h
+    cpp/hs_Exception.h
     cpp/hs_Font_BRepFont.h
     cpp/hs_Font_BRepTextBuilder.h
     cpp/hs_GC_MakeArcOfCircle.h
@@ -260,6 +261,7 @@ library
       OpenCascade.IFSelect.ReturnStatus
       OpenCascade.Inheritance
       OpenCascade.Internal.Bool
+      OpenCascade.Internal.Exception
       OpenCascade.Message.Internal.Destructors
       OpenCascade.Message.ProgressRange
       OpenCascade.Message.Types

--- a/opencascade-hs/opencascade-hs.cabal
+++ b/opencascade-hs/opencascade-hs.cabal
@@ -102,6 +102,7 @@ extra-source-files:
     cpp/hs_ShapeConstruct_Curve.h
     cpp/hs_ShapeExtend_WireData.h
     cpp/hs_ShapeFix_Solid.h
+    cpp/hs_Standard_Failure.h
     cpp/hs_STEPControl_Reader.h
     cpp/hs_STEPControl_Writer.h
     cpp/hs_StlAPI_Reader.h
@@ -293,6 +294,12 @@ library
       OpenCascade.ShapeFix.Internal.Destructors
       OpenCascade.ShapeFix.Solid
       OpenCascade.ShapeFix.Types
+      OpenCascade.Standard.Failure
+      OpenCascade.Standard.Internal.Destructors
+      OpenCascade.Standard.Types
+      OpenCascade.Std.Exception
+      OpenCascade.Std.Internal.Destructors
+      OpenCascade.Std.Types
       OpenCascade.STEPControl
       OpenCascade.STEPControl.Internal.Destructors
       OpenCascade.STEPControl.Reader
@@ -394,6 +401,7 @@ library
       cpp/hs_BRepPrimAPI_MakeSphere.cpp
       cpp/hs_BRepPrimAPI_MakeTorus.cpp
       cpp/hs_BRepTools_WireExplorer.cpp
+      cpp/hs_Exception.cpp
       cpp/hs_Font_BRepFont.cpp
       cpp/hs_Font_BRepTextBuilder.cpp
       cpp/hs_GC_MakeArcOfCircle.cpp
@@ -437,6 +445,7 @@ library
       cpp/hs_ShapeConstruct_Curve.cpp
       cpp/hs_ShapeExtend_WireData.cpp
       cpp/hs_ShapeFix_Solid.cpp
+      cpp/hs_Standard_Failure.cpp
       cpp/hs_STEPControl_Reader.cpp
       cpp/hs_STEPControl_Writer.cpp
       cpp/hs_StlAPI_Reader.cpp

--- a/opencascade-hs/src/OpenCascade/BOPAlgo/BOP.hs
+++ b/opencascade-hs/src/OpenCascade/BOPAlgo/BOP.hs
@@ -9,6 +9,7 @@ module OpenCascade.BOPAlgo.BOP
 import OpenCascade.BOPAlgo.Types
 import OpenCascade.BOPAlgo.Internal.Destructors (deleteBOP)
 import OpenCascade.BOPAlgo.Operation (Operation)
+import OpenCascade.Internal.Exception (wrapException)
 import qualified OpenCascade.TopoDS.Types as TopoDS
 
 import Foreign.Ptr (Ptr)
@@ -21,7 +22,15 @@ foreign import capi unsafe "hs_BOPAlgo_BOP.h hs_new_BOPAlgo_BOP" rawNew :: IO (P
 new :: Acquire (Ptr BOP)
 new = mkAcquire rawNew deleteBOP
 
-foreign import capi unsafe "hs_BOPAlgo_BOP.h hs_BOPAlgo_BOP_AddTool" addTool :: Ptr BOP -> Ptr TopoDS.Shape -> IO ()
+foreign import capi unsafe "hs_BOPAlgo_BOP.h hs_BOPAlgo_BOP_AddTool" rawAddTool
+    :: Ptr BOP
+    -> Ptr TopoDS.Shape
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
+
+addTool :: Ptr BOP -> Ptr TopoDS.Shape -> IO ()
+addTool bop tool = wrapException $ rawAddTool bop tool
 
 foreign import capi unsafe "hs_BOPAlgo_BOP.h hs_BOPAlgo_BOP_SetOperation" rawSetOperation :: Ptr BOP -> CInt -> IO ()
 

--- a/opencascade-hs/src/OpenCascade/BOPAlgo/Builder.hs
+++ b/opencascade-hs/src/OpenCascade/BOPAlgo/Builder.hs
@@ -12,8 +12,9 @@ import OpenCascade.BOPAlgo.Types
 import OpenCascade.BOPAlgo.Internal.Destructors (deleteBuilder)
 import qualified OpenCascade.TopoDS.Types as TopoDS
 import OpenCascade.TopoDS.Internal.Destructors (deleteShape)
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.Ptr (Ptr)
-import Foreign.C (CBool (..))
+import Foreign.C (CBool (..), CInt)
 import Data.Acquire (Acquire, mkAcquire)
 import OpenCascade.Internal.Bool (boolToCBool)
 
@@ -22,18 +23,37 @@ foreign import capi unsafe "hs_BOPAlgo_Builder.h hs_new_BOPAlgo_Builder" rawNew 
 new :: Acquire (Ptr Builder)
 new = mkAcquire rawNew deleteBuilder
 
-foreign import capi unsafe "hs_BOPAlgo_Builder.h hs_BOPAlgo_Builder_AddArgument" addArgument :: Ptr Builder -> Ptr TopoDS.Shape -> IO ()
+foreign import capi unsafe "hs_BOPAlgo_Builder.h hs_BOPAlgo_Builder_AddArgument" rawAddArgument
+    :: Ptr Builder
+    -> Ptr TopoDS.Shape
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
+
+addArgument :: Ptr Builder -> Ptr TopoDS.Shape -> IO ()
+addArgument builder shape' = wrapException $ rawAddArgument builder shape'
 
 foreign import capi unsafe "hs_BOPAlgo_Builder.h hs_BOPAlgo_Builder_SetRunParallel" rawSetRunParallel :: Ptr Builder -> CBool -> IO ()
 
 setRunParallel :: Ptr Builder -> Bool -> IO ()
 setRunParallel builder = rawSetRunParallel builder . boolToCBool
 
-foreign import capi unsafe "hs_BOPAlgo_Builder.h hs_BOPAlgo_Builder_Shape" rawShape :: Ptr Builder -> IO (Ptr TopoDS.Shape)
+foreign import capi unsafe "hs_BOPAlgo_Builder.h hs_BOPAlgo_Builder_Shape" rawShape
+    :: Ptr Builder
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Shape)
 
 shape :: Ptr Builder -> Acquire (Ptr TopoDS.Shape)
-shape builder = mkAcquire (rawShape builder) deleteShape  
+shape builder = mkAcquire (wrapException $ rawShape builder) deleteShape
 
 
-foreign import capi unsafe "hs_BOPAlgo_Builder.h hs_BOPAlgo_Builder_Perform" perform :: Ptr Builder -> IO ()
+foreign import capi unsafe "hs_BOPAlgo_Builder.h hs_BOPAlgo_Builder_Perform" rawPerform
+    :: Ptr Builder
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
+
+perform :: Ptr Builder -> IO ()
+perform builder = wrapException $ rawPerform builder
 

--- a/opencascade-hs/src/OpenCascade/BRep/Tool.hs
+++ b/opencascade-hs/src/OpenCascade/BRep/Tool.hs
@@ -17,32 +17,54 @@ import OpenCascade.Poly.Internal.Destructors (deleteHandleTriangulation)
 import OpenCascade.Handle (Handle)
 import OpenCascade.Geom.Internal.Destructors (deleteHandleCurve)
 import OpenCascade.GP.Internal.Destructors (deletePnt)
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.Ptr
 import Foreign.C
 import Data.Coerce
 import Data.Acquire (Acquire, mkAcquire)
 
-foreign import capi unsafe "hs_BRep_Tool.h hs_BRep_Tool_curve" rawCurve :: Ptr (TopoDS.Edge) -> IO(Ptr (Handle Geom.Curve))
+foreign import capi unsafe "hs_BRep_Tool.h hs_BRep_Tool_curve" rawCurve
+    :: Ptr (TopoDS.Edge)
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr (Handle Geom.Curve))
 
 curve :: Ptr TopoDS.Edge -> Acquire (Ptr (Handle Geom.Curve))
-curve edge = mkAcquire (rawCurve edge) deleteHandleCurve
+curve edge = mkAcquire (wrapException $ rawCurve edge) deleteHandleCurve
 
-foreign import capi unsafe "hs_BRep_Tool.h hs_BRep_Tool_curveParamFirst" rawCurveParamFirst :: Ptr (TopoDS.Edge) -> IO(CDouble)
+foreign import capi unsafe "hs_BRep_Tool.h hs_BRep_Tool_curveParamFirst" rawCurveParamFirst
+    :: Ptr (TopoDS.Edge)
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (CDouble)
 
-curveParamFirst :: Ptr TopoDS.Edge -> IO Double 
-curveParamFirst = coerce rawCurveParamFirst
+curveParamFirst :: Ptr TopoDS.Edge -> IO Double
+curveParamFirst edge = coerce <$> wrapException (rawCurveParamFirst edge)
 
-foreign import capi unsafe "hs_BRep_Tool.h hs_BRep_Tool_curveParamLast" rawCurveParamLast :: Ptr (TopoDS.Edge) -> IO(CDouble)
+foreign import capi unsafe "hs_BRep_Tool.h hs_BRep_Tool_curveParamLast" rawCurveParamLast
+    :: Ptr (TopoDS.Edge)
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (CDouble)
 
-curveParamLast :: Ptr TopoDS.Edge -> IO Double 
-curveParamLast = coerce rawCurveParamLast
+curveParamLast :: Ptr TopoDS.Edge -> IO Double
+curveParamLast edge = coerce <$> wrapException (rawCurveParamLast edge)
 
-foreign import capi unsafe "hs_BRep_Tool.h hs_BRep_Tool_pnt" rawPnt :: Ptr (TopoDS.Vertex) -> IO (Ptr GP.Pnt)
+foreign import capi unsafe "hs_BRep_Tool.h hs_BRep_Tool_pnt" rawPnt
+    :: Ptr (TopoDS.Vertex)
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr GP.Pnt)
 
 pnt :: Ptr TopoDS.Vertex -> Acquire (Ptr GP.Pnt)
-pnt v = mkAcquire (rawPnt v) deletePnt
+pnt v = mkAcquire (wrapException $ rawPnt v) deletePnt
 
-foreign import capi unsafe "hs_BRep_Tool.h hs_BRep_Tool_triangulation" rawTriangulation :: Ptr (TopoDS.Face) -> Ptr TopLoc.Location -> IO(Ptr (Handle Poly.Triangulation))
+foreign import capi unsafe "hs_BRep_Tool.h hs_BRep_Tool_triangulation" rawTriangulation
+    :: Ptr (TopoDS.Face)
+    -> Ptr TopLoc.Location
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr (Handle Poly.Triangulation))
 
 triangulation :: Ptr TopoDS.Face -> Ptr TopLoc.Location -> Acquire (Ptr (Handle Poly.Triangulation))
-triangulation face loc = mkAcquire (rawTriangulation face loc) deleteHandleTriangulation
+triangulation face loc = mkAcquire (wrapException $ rawTriangulation face loc) deleteHandleTriangulation

--- a/opencascade-hs/src/OpenCascade/BRepAdaptor/Curve.hs
+++ b/opencascade-hs/src/OpenCascade/BRepAdaptor/Curve.hs
@@ -23,11 +23,16 @@ import OpenCascade.Handle (Handle)
 import Data.Coerce (coerce)
 import qualified OpenCascade.GeomAdaptor.Types as GeomAdaptor
 import qualified OpenCascade.GeomAdaptor.Internal.Destructors as GeomAdaptor.Destructors
+import OpenCascade.Internal.Exception (wrapException)
 
-foreign import capi unsafe "hs_BRepAdaptor_Curve.h hs_new_BRepAdaptor_Curve_fromEdge" rawFromEdge :: Ptr TopoDS.Edge -> IO (Ptr Curve)
+foreign import capi unsafe "hs_BRepAdaptor_Curve.h hs_new_BRepAdaptor_Curve_fromEdge" rawFromEdge
+    :: Ptr TopoDS.Edge
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr Curve)
 
 fromEdge :: Ptr TopoDS.Edge -> Acquire (Ptr Curve)
-fromEdge e = mkAcquire (rawFromEdge e) deleteCurve
+fromEdge e = mkAcquire (wrapException $ rawFromEdge e) deleteCurve
 
 
 foreign import capi unsafe "hs_BRepAdaptor_Curve.h hs_BRepAdaptor_Curve_curveType" rawCurveType :: Ptr Curve -> IO (CInt)
@@ -35,21 +40,33 @@ foreign import capi unsafe "hs_BRepAdaptor_Curve.h hs_BRepAdaptor_Curve_curveTyp
 curveType :: Ptr Curve -> IO CurveType
 curveType c = toEnum . fromIntegral <$> rawCurveType c
 
-foreign import capi unsafe "hs_BRepAdaptor_Curve.h hs_BRepAdaptor_Curve_bezier" rawBezier :: Ptr Curve -> IO (Ptr (Handle (Geom.BezierCurve)))
+foreign import capi unsafe "hs_BRepAdaptor_Curve.h hs_BRepAdaptor_Curve_bezier" rawBezier
+    :: Ptr Curve
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr (Handle (Geom.BezierCurve)))
 
 bezier :: Ptr Curve -> Acquire (Ptr (Handle Geom.BezierCurve))
-bezier theCurve = mkAcquire (rawBezier theCurve) deleteHandleBezierCurve
+bezier theCurve = mkAcquire (wrapException $ rawBezier theCurve) deleteHandleBezierCurve
 
-foreign import capi unsafe "hs_BRepAdaptor_Curve.h hs_BRepAdaptor_Curve_bspline" rawBSpline :: Ptr Curve -> IO (Ptr (Handle (Geom.BSplineCurve)))
+foreign import capi unsafe "hs_BRepAdaptor_Curve.h hs_BRepAdaptor_Curve_bspline" rawBSpline
+    :: Ptr Curve
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr (Handle (Geom.BSplineCurve)))
 
 bspline :: Ptr Curve -> Acquire (Ptr (Handle Geom.BSplineCurve))
-bspline theCurve = mkAcquire (rawBSpline theCurve) deleteHandleBSplineCurve
+bspline theCurve = mkAcquire (wrapException $ rawBSpline theCurve) deleteHandleBSplineCurve
 
 
-foreign import capi unsafe "hs_BRepAdaptor_Curve.h hs_BRepAdaptor_Curve_curve" rawCurve :: Ptr Curve -> IO (Ptr GeomAdaptor.Curve)
+foreign import capi unsafe "hs_BRepAdaptor_Curve.h hs_BRepAdaptor_Curve_curve" rawCurve
+    :: Ptr Curve
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr GeomAdaptor.Curve)
 
 curve :: Ptr Curve -> Acquire (Ptr GeomAdaptor.Curve)
-curve theCurve = mkAcquire (rawCurve theCurve) GeomAdaptor.Destructors.deleteCurve
+curve theCurve = mkAcquire (wrapException $ rawCurve theCurve) GeomAdaptor.Destructors.deleteCurve
 
 foreign import capi unsafe "hs_BRepAdaptor_Curve.h hs_BRepAdaptor_Curve_firstParameter" rawFirstParameter :: Ptr Curve -> IO CDouble
 

--- a/opencascade-hs/src/OpenCascade/BRepAlgoAPI/Common.hs
+++ b/opencascade-hs/src/OpenCascade/BRepAlgoAPI/Common.hs
@@ -5,11 +5,18 @@ module OpenCascade.BRepAlgoAPI.Common
 
 import qualified OpenCascade.TopoDS as TopoDS
 import OpenCascade.TopoDS.Internal.Destructors (deleteShape)
+import OpenCascade.Internal.Exception (wrapException)
+import Foreign.C (CInt)
 import Foreign.Ptr
 import Data.Acquire
 
 
-foreign import capi unsafe "hs_BRepAlgoAPI_Common.h hs_BRepAlgoAPI_Common" rawCommon :: Ptr TopoDS.Shape -> Ptr TopoDS.Shape ->  IO (Ptr TopoDS.Shape)
+foreign import capi unsafe "hs_BRepAlgoAPI_Common.h hs_BRepAlgoAPI_Common" rawCommon
+    :: Ptr TopoDS.Shape
+    -> Ptr TopoDS.Shape
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Shape)
 
 common :: Ptr TopoDS.Shape -> Ptr TopoDS.Shape -> Acquire (Ptr TopoDS.Shape)
-common a b = mkAcquire (rawCommon a b) deleteShape
+common a b = mkAcquire (wrapException $ rawCommon a b) deleteShape

--- a/opencascade-hs/src/OpenCascade/BRepAlgoAPI/Cut.hs
+++ b/opencascade-hs/src/OpenCascade/BRepAlgoAPI/Cut.hs
@@ -5,11 +5,18 @@ module OpenCascade.BRepAlgoAPI.Cut
 
 import qualified OpenCascade.TopoDS as TopoDS
 import OpenCascade.TopoDS.Internal.Destructors (deleteShape)
+import OpenCascade.Internal.Exception (wrapException)
+import Foreign.C (CInt)
 import Foreign.Ptr
 import Data.Acquire
 
 
-foreign import capi unsafe "hs_BRepAlgoAPI_Cut.h hs_BRepAlgoAPI_Cut" rawCut :: Ptr TopoDS.Shape -> Ptr TopoDS.Shape ->  IO (Ptr TopoDS.Shape)
+foreign import capi unsafe "hs_BRepAlgoAPI_Cut.h hs_BRepAlgoAPI_Cut" rawCut
+    :: Ptr TopoDS.Shape
+    -> Ptr TopoDS.Shape
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Shape)
 
 cut :: Ptr TopoDS.Shape -> Ptr TopoDS.Shape -> Acquire (Ptr TopoDS.Shape)
-cut a b = mkAcquire (rawCut a b) deleteShape
+cut a b = mkAcquire (wrapException $ rawCut a b) deleteShape

--- a/opencascade-hs/src/OpenCascade/BRepAlgoAPI/Fuse.hs
+++ b/opencascade-hs/src/OpenCascade/BRepAlgoAPI/Fuse.hs
@@ -5,11 +5,18 @@ module OpenCascade.BRepAlgoAPI.Fuse
 
 import qualified OpenCascade.TopoDS as TopoDS
 import OpenCascade.TopoDS.Internal.Destructors (deleteShape)
+import OpenCascade.Internal.Exception (wrapException)
+import Foreign.C (CInt)
 import Foreign.Ptr
 import Data.Acquire
 
 
-foreign import capi unsafe "hs_BRepAlgoAPI_Fuse.h hs_BRepAlgoAPI_Fuse" rawFuse :: Ptr TopoDS.Shape -> Ptr TopoDS.Shape ->  IO (Ptr TopoDS.Shape)
+foreign import capi unsafe "hs_BRepAlgoAPI_Fuse.h hs_BRepAlgoAPI_Fuse" rawFuse
+    :: Ptr TopoDS.Shape
+    -> Ptr TopoDS.Shape
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Shape)
 
 fuse :: Ptr TopoDS.Shape -> Ptr TopoDS.Shape -> Acquire (Ptr TopoDS.Shape)
-fuse a b = mkAcquire (rawFuse a b) deleteShape
+fuse a b = mkAcquire (wrapException $ rawFuse a b) deleteShape

--- a/opencascade-hs/src/OpenCascade/BRepBndLib.hs
+++ b/opencascade-hs/src/OpenCascade/BRepBndLib.hs
@@ -8,27 +8,49 @@ module OpenCascade.BRepBndLib
 import OpenCascade.TopoDS.Types (Shape)
 import OpenCascade.Bnd.Types (Box, OBB)
 import Foreign.Ptr (Ptr)
-import Foreign.C (CBool (..))
+import Foreign.C (CBool (..), CInt)
 import OpenCascade.Internal.Bool (boolToCBool)
+import OpenCascade.Internal.Exception (wrapException)
 
-foreign import capi unsafe "hs_BRepBndLib.h hs_BRepBndLib_add" rawAdd ::  Ptr Shape -> Ptr Box -> CBool -> IO ()
+foreign import capi unsafe "hs_BRepBndLib.h hs_BRepBndLib_add" rawAdd
+    :: Ptr Shape
+    -> Ptr Box
+    -> CBool
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
 
 add :: Ptr Shape  -> Ptr Box -> Bool -> IO ()
-add shape box useTriangulation = rawAdd shape box (boolToCBool useTriangulation)
+add shape box useTriangulation = wrapException $ rawAdd shape box (boolToCBool useTriangulation)
 
-foreign import capi unsafe "hs_BRepBndLib.h hs_BRepBndLib_addOptimal" rawAddOptimal ::  Ptr Shape -> Ptr Box -> CBool -> CBool -> IO ()
+foreign import capi unsafe "hs_BRepBndLib.h hs_BRepBndLib_addOptimal" rawAddOptimal
+    :: Ptr Shape
+    -> Ptr Box
+    -> CBool
+    -> CBool
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
 
 addOptimal :: Ptr Shape  -> Ptr Box -> Bool -- ^ useTriangulation
     -> Bool -- ^ useShapeTolerance
     -> IO ()
-addOptimal shape box useTriangulation useShapeTolerance = 
-    rawAddOptimal shape box (boolToCBool useTriangulation) (boolToCBool useShapeTolerance)
+addOptimal shape box useTriangulation useShapeTolerance =
+    wrapException $ rawAddOptimal shape box (boolToCBool useTriangulation) (boolToCBool useShapeTolerance)
 
-foreign import capi unsafe "hs_BRepBndLib.h hs_BRepBndLib_addOBB" rawAddOBB ::  Ptr Shape -> Ptr OBB -> CBool -> CBool -> CBool -> IO ()
+foreign import capi unsafe "hs_BRepBndLib.h hs_BRepBndLib_addOBB" rawAddOBB
+    :: Ptr Shape
+    -> Ptr OBB
+    -> CBool
+    -> CBool
+    -> CBool
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
 
 addOBB :: Ptr Shape -> Ptr OBB -> Bool -- ^ isTriangulation used
     -> Bool -- ^ isOptimal
     -> Bool -- ^ is ShapeToleranceUsed
     -> IO ()
-addOBB shape obb triangulationUsed optimal shapeToleranceUsed = 
-    rawAddOBB shape obb (boolToCBool triangulationUsed) (boolToCBool optimal) (boolToCBool shapeToleranceUsed)
+addOBB shape obb triangulationUsed optimal shapeToleranceUsed =
+    wrapException $ rawAddOBB shape obb (boolToCBool triangulationUsed) (boolToCBool optimal) (boolToCBool shapeToleranceUsed)

--- a/opencascade-hs/src/OpenCascade/BRepBuilderAPI/Copy.hs
+++ b/opencascade-hs/src/OpenCascade/BRepBuilderAPI/Copy.hs
@@ -6,11 +6,18 @@ module OpenCascade.BRepBuilderAPI.Copy
 import qualified OpenCascade.TopoDS as TopoDS
 import OpenCascade.Internal.Bool
 import qualified OpenCascade.TopoDS.Internal.Destructors as TopoDS.Destructors
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.C
 import Foreign.Ptr
-import Data.Acquire 
+import Data.Acquire
 
-foreign import capi unsafe "hs_BRepBuilderAPI_Copy.h hs_BRepBuilderAPI_Copy_copy" rawCopy :: Ptr TopoDS.Shape -> CBool -> CBool -> IO (Ptr TopoDS.Shape)
+foreign import capi unsafe "hs_BRepBuilderAPI_Copy.h hs_BRepBuilderAPI_Copy_copy" rawCopy
+    :: Ptr TopoDS.Shape
+    -> CBool
+    -> CBool
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Shape)
 
 copy :: Ptr TopoDS.Shape -> Bool -> Bool -> Acquire (Ptr TopoDS.Shape)
-copy shape copyGeom copyMesh = mkAcquire (rawCopy shape (boolToCBool copyMesh) (boolToCBool copyGeom)) TopoDS.Destructors.deleteShape
+copy shape copyGeom copyMesh = mkAcquire (wrapException $ rawCopy shape (boolToCBool copyMesh) (boolToCBool copyGeom)) TopoDS.Destructors.deleteShape

--- a/opencascade-hs/src/OpenCascade/BRepBuilderAPI/GTransform.hs
+++ b/opencascade-hs/src/OpenCascade/BRepBuilderAPI/GTransform.hs
@@ -7,11 +7,18 @@ import qualified OpenCascade.GP as GP
 import qualified OpenCascade.TopoDS as TopoDS
 import OpenCascade.Internal.Bool
 import qualified OpenCascade.TopoDS.Internal.Destructors as TopoDS.Destructors
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.C
 import Foreign.Ptr
-import Data.Acquire 
+import Data.Acquire
 
-foreign import capi unsafe "hs_BRepBuilderAPI_GTransform.h hs_BRepBuilderAPI_GTransform_gtransform" rawGTransform :: Ptr TopoDS.Shape -> Ptr GP.GTrsf -> CBool -> IO (Ptr TopoDS.Shape)
+foreign import capi unsafe "hs_BRepBuilderAPI_GTransform.h hs_BRepBuilderAPI_GTransform_gtransform" rawGTransform
+    :: Ptr TopoDS.Shape
+    -> Ptr GP.GTrsf
+    -> CBool
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Shape)
 
 gtransform :: Ptr TopoDS.Shape -> Ptr GP.GTrsf -> Bool -> Acquire (Ptr TopoDS.Shape)
-gtransform shape trsf copy = mkAcquire (rawGTransform shape trsf (boolToCBool copy)) TopoDS.Destructors.deleteShape
+gtransform shape trsf copy = mkAcquire (wrapException $ rawGTransform shape trsf (boolToCBool copy)) TopoDS.Destructors.deleteShape

--- a/opencascade-hs/src/OpenCascade/BRepBuilderAPI/MakeEdge.hs
+++ b/opencascade-hs/src/OpenCascade/BRepBuilderAPI/MakeEdge.hs
@@ -16,6 +16,7 @@ import qualified OpenCascade.GP as GP
 import qualified OpenCascade.Geom as Geom
 import OpenCascade.Handle
 import OpenCascade.Inheritance
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.C
 import Foreign.Ptr
 import Data.Acquire 
@@ -23,62 +24,134 @@ import Data.Acquire
 
 -- fromVertices
 
-foreign import capi unsafe "hs_BRepBuilderAPI_MakeEdge.h hs_BRepBuilderAPI_MakeEdge_fromVertices" rawFromVertices :: Ptr TopoDS.Vertex -> Ptr TopoDS.Vertex -> IO (Ptr TopoDS.Edge)
+foreign import capi unsafe "hs_BRepBuilderAPI_MakeEdge.h hs_BRepBuilderAPI_MakeEdge_fromVertices" rawFromVertices 
+    :: Ptr TopoDS.Vertex 
+    -> Ptr TopoDS.Vertex 
+    -> Ptr CInt 
+    -> Ptr (Ptr ()) 
+    -> IO (Ptr TopoDS.Edge)
 
 fromVertices :: Ptr TopoDS.Vertex -> Ptr TopoDS.Vertex -> Acquire (Ptr TopoDS.Edge)
-fromVertices start end = mkAcquire (rawFromVertices start end) (TopoDS.Destructors.deleteShape . upcast)
+fromVertices start end = 
+    mkAcquire 
+        (wrapException $ rawFromVertices start end)
+        (TopoDS.Destructors.deleteShape . upcast)
 
 
 -- fromPnts
 
-foreign import capi unsafe "hs_BRepBuilderAPI_MakeEdge.h hs_BRepBuilderAPI_MakeEdge_fromPnts" rawFromPnts :: Ptr GP.Pnt -> Ptr GP.Pnt -> IO (Ptr TopoDS.Edge)
+foreign import capi unsafe "hs_BRepBuilderAPI_MakeEdge.h hs_BRepBuilderAPI_MakeEdge_fromPnts" rawFromPnts 
+    :: Ptr GP.Pnt
+    -> Ptr GP.Pnt
+    -> Ptr CInt 
+    -> Ptr (Ptr ()) 
+    -> IO (Ptr TopoDS.Edge)
 
 fromPnts :: Ptr GP.Pnt -> Ptr GP.Pnt -> Acquire (Ptr TopoDS.Edge)
-fromPnts start end = mkAcquire (rawFromPnts start end) (TopoDS.Destructors.deleteShape . upcast)
+fromPnts start end = 
+    mkAcquire
+        (wrapException $ rawFromPnts start end) 
+        (TopoDS.Destructors.deleteShape . upcast)
 
 
 -- fromCurve
 
-foreign import capi unsafe "hs_BRepBuilderAPI_MakeEdge.h hs_BRepBuilderAPI_MakeEdge_fromCurve" rawFromCurve :: Ptr (Handle Geom.Curve) -> IO (Ptr TopoDS.Edge)
+foreign import capi unsafe "hs_BRepBuilderAPI_MakeEdge.h hs_BRepBuilderAPI_MakeEdge_fromCurve" rawFromCurve 
+    :: Ptr (Handle Geom.Curve) 
+    -> Ptr CInt 
+    -> Ptr (Ptr ()) 
+    -> IO (Ptr TopoDS.Edge)
 
 fromCurve :: Ptr (Handle Geom.Curve) -> Acquire (Ptr TopoDS.Edge)
-fromCurve curve = mkAcquire (rawFromCurve curve) (TopoDS.Destructors.deleteShape . upcast)
+fromCurve curve = 
+    mkAcquire 
+        (wrapException $ rawFromCurve curve)
+        (TopoDS.Destructors.deleteShape . upcast)
 
 -- fromCurveAndParameters
 
-foreign import capi unsafe "hs_BRepBuilderAPI_MakeEdge.h hs_BRepBuilderAPI_MakeEdge_fromCurveAndParameters" rawFromCurveAndParameters :: Ptr (Handle Geom.Curve) -> CDouble -> CDouble -> IO (Ptr TopoDS.Edge)
+foreign import capi unsafe "hs_BRepBuilderAPI_MakeEdge.h hs_BRepBuilderAPI_MakeEdge_fromCurveAndParameters" rawFromCurveAndParameters 
+    :: Ptr (Handle Geom.Curve)
+    -> CDouble
+    -> CDouble
+    -> Ptr CInt 
+    -> Ptr (Ptr ()) 
+    -> IO (Ptr TopoDS.Edge)
 
 fromCurveAndParameters :: Ptr (Handle Geom.Curve) -> Double -> Double -> Acquire (Ptr TopoDS.Edge)
-fromCurveAndParameters curve p1 p2 = mkAcquire (rawFromCurveAndParameters curve (CDouble p1) (CDouble p2)) (TopoDS.Destructors.deleteShape . upcast)
+fromCurveAndParameters curve p1 p2 =
+    mkAcquire
+        (wrapException $ rawFromCurveAndParameters curve (CDouble p1) (CDouble p2))
+        (TopoDS.Destructors.deleteShape . upcast)
 
 
 -- fromCurveAndVertices
 
-foreign import capi unsafe "hs_BRepBuilderAPI_MakeEdge.h hs_BRepBuilderAPI_MakeEdge_fromCurveAndVertices" rawFromCurveAndVertices :: Ptr (Handle Geom.Curve) -> Ptr TopoDS.Vertex -> Ptr TopoDS.Vertex -> IO (Ptr TopoDS.Edge)
+foreign import capi unsafe "hs_BRepBuilderAPI_MakeEdge.h hs_BRepBuilderAPI_MakeEdge_fromCurveAndVertices" rawFromCurveAndVertices 
+    :: Ptr (Handle Geom.Curve) 
+    -> Ptr TopoDS.Vertex 
+    -> Ptr TopoDS.Vertex
+    -> Ptr CInt 
+    -> Ptr (Ptr ()) 
+    -> IO (Ptr TopoDS.Edge)
 
 fromCurveAndVertices :: Ptr (Handle Geom.Curve) -> Ptr TopoDS.Vertex -> Ptr TopoDS.Vertex -> Acquire (Ptr TopoDS.Edge)
-fromCurveAndVertices curve v1 v2 = mkAcquire (rawFromCurveAndVertices curve v1 v2) (TopoDS.Destructors.deleteShape . upcast)
+fromCurveAndVertices curve v1 v2 = 
+    mkAcquire 
+        (wrapException $ rawFromCurveAndVertices curve v1 v2) 
+        (TopoDS.Destructors.deleteShape . upcast)
 
 
 -- fromCurveAndPnts
 
-foreign import capi unsafe "hs_BRepBuilderAPI_MakeEdge.h hs_BRepBuilderAPI_MakeEdge_fromCurveAndPnts" rawFromCurveAndPnts :: Ptr (Handle Geom.Curve) -> Ptr GP.Pnt -> Ptr GP.Pnt -> IO (Ptr TopoDS.Edge)
+foreign import capi unsafe "hs_BRepBuilderAPI_MakeEdge.h hs_BRepBuilderAPI_MakeEdge_fromCurveAndPnts" rawFromCurveAndPnts 
+    :: Ptr (Handle Geom.Curve) 
+    -> Ptr GP.Pnt
+    -> Ptr GP.Pnt 
+    -> Ptr CInt 
+    -> Ptr (Ptr ()) 
+    -> IO (Ptr TopoDS.Edge)
 
 fromCurveAndPnts :: Ptr (Handle Geom.Curve) -> Ptr GP.Pnt -> Ptr GP.Pnt -> Acquire (Ptr TopoDS.Edge)
-fromCurveAndPnts curve v1 v2 = mkAcquire (rawFromCurveAndPnts curve v1 v2) (TopoDS.Destructors.deleteShape . upcast)
+fromCurveAndPnts curve v1 v2 = 
+    mkAcquire 
+        (wrapException $ rawFromCurveAndPnts curve v1 v2)
+        (TopoDS.Destructors.deleteShape . upcast)
 
 
 -- fromCurveVerticesAndParameters
 
-foreign import capi unsafe "hs_BRepBuilderAPI_MakeEdge.h hs_BRepBuilderAPI_MakeEdge_fromCurveVerticesAndParameters" rawFromCurveVerticesAndParameters :: Ptr (Handle Geom.Curve) -> Ptr TopoDS.Vertex -> Ptr TopoDS.Vertex -> CDouble -> CDouble -> IO (Ptr TopoDS.Edge)
+foreign import capi unsafe "hs_BRepBuilderAPI_MakeEdge.h hs_BRepBuilderAPI_MakeEdge_fromCurveVerticesAndParameters" rawFromCurveVerticesAndParameters 
+    :: Ptr (Handle Geom.Curve) 
+    -> Ptr TopoDS.Vertex 
+    -> Ptr TopoDS.Vertex 
+    -> CDouble 
+    -> CDouble 
+    -> Ptr CInt 
+    -> Ptr (Ptr ()) 
+    -> IO (Ptr TopoDS.Edge)
 
 fromCurveVerticesAndParameters :: Ptr (Handle Geom.Curve) -> Ptr TopoDS.Vertex -> Ptr TopoDS.Vertex -> Double -> Double -> Acquire (Ptr TopoDS.Edge)
-fromCurveVerticesAndParameters curve v1 v2 p1 p2 = mkAcquire (rawFromCurveVerticesAndParameters curve v1 v2 (CDouble p1) (CDouble p2)) (TopoDS.Destructors.deleteShape . upcast)
+fromCurveVerticesAndParameters curve v1 v2 p1 p2 = 
+    mkAcquire 
+        (wrapException $ rawFromCurveVerticesAndParameters curve v1 v2 (CDouble p1) (CDouble p2))
+        (TopoDS.Destructors.deleteShape . upcast)
 
 
 -- fromCurvePntsAndParameters
 
-foreign import capi unsafe "hs_BRepBuilderAPI_MakeEdge.h hs_BRepBuilderAPI_MakeEdge_fromCurvePntsAndParameters" rawFromCurvePntsAndParameters :: Ptr (Handle Geom.Curve) -> Ptr GP.Pnt -> Ptr GP.Pnt -> CDouble -> CDouble -> IO (Ptr TopoDS.Edge)
+foreign import capi unsafe "hs_BRepBuilderAPI_MakeEdge.h hs_BRepBuilderAPI_MakeEdge_fromCurvePntsAndParameters" rawFromCurvePntsAndParameters 
+    :: Ptr (Handle Geom.Curve)
+    -> Ptr GP.Pnt 
+    -> Ptr GP.Pnt 
+    -> CDouble 
+    -> CDouble 
+    -> Ptr CInt 
+    -> Ptr (Ptr ()) 
+    -> IO (Ptr TopoDS.Edge)
 
 fromCurvePntsAndParameters :: Ptr (Handle Geom.Curve) -> Ptr GP.Pnt -> Ptr GP.Pnt -> Double -> Double -> Acquire (Ptr TopoDS.Edge)
-fromCurvePntsAndParameters curve v1 v2 p1 p2 = mkAcquire (rawFromCurvePntsAndParameters curve v1 v2 (CDouble p1) (CDouble p2)) (TopoDS.Destructors.deleteShape . upcast)
+fromCurvePntsAndParameters curve v1 v2 p1 p2 =
+    mkAcquire 
+        (wrapException $ rawFromCurvePntsAndParameters curve v1 v2 (CDouble p1) (CDouble p2))
+        (TopoDS.Destructors.deleteShape . upcast)

--- a/opencascade-hs/src/OpenCascade/BRepBuilderAPI/MakeFace.hs
+++ b/opencascade-hs/src/OpenCascade/BRepBuilderAPI/MakeFace.hs
@@ -23,6 +23,7 @@ import OpenCascade.TopoDS.Internal.Destructors (deleteShape)
 import OpenCascade.Inheritance (upcast)
 import qualified OpenCascade.Geom as Geom
 import OpenCascade.BRepBuilderAPI.FaceError (FaceError)
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.C
 import Foreign.Ptr
 import Data.Acquire 
@@ -36,41 +37,78 @@ new = mkAcquire rawNew deleteMakeFace
 
 -- fromFace
 
-foreign import capi unsafe "hs_BRepBuilderAPI_MakeFace.h hs_new_BRepBuilderAPI_MakeFace_fromFace" rawFromFace :: Ptr TopoDS.Face ->  IO (Ptr MakeFace)
+foreign import capi unsafe "hs_BRepBuilderAPI_MakeFace.h hs_new_BRepBuilderAPI_MakeFace_fromFace" rawFromFace
+    :: Ptr TopoDS.Face
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr MakeFace)
 
 fromFace :: Ptr TopoDS.Face -> Acquire (Ptr MakeFace)
-fromFace theFace = mkAcquire (rawFromFace theFace) deleteMakeFace
+fromFace theFace = mkAcquire (wrapException $ rawFromFace theFace) deleteMakeFace
 
 -- fromSurface
 
-foreign import capi unsafe "hs_BRepBuilderAPI_MakeFace.h hs_new_BRepBuilderAPI_MakeFace_fromSurface" rawFromSurface :: Ptr (Handle (Geom.Surface)) -> CDouble -> IO (Ptr MakeFace)
+foreign import capi unsafe "hs_BRepBuilderAPI_MakeFace.h hs_new_BRepBuilderAPI_MakeFace_fromSurface" rawFromSurface
+    :: Ptr (Handle (Geom.Surface))
+    -> CDouble
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr MakeFace)
 
 fromSurface :: Ptr (Handle Geom.Surface) -> Double -> Acquire (Ptr MakeFace)
-fromSurface surf tolerance = mkAcquire (rawFromSurface surf (CDouble tolerance)) deleteMakeFace
+fromSurface surf tolerance = mkAcquire (wrapException $ rawFromSurface surf (CDouble tolerance)) deleteMakeFace
 
 -- fromSurfaceAndBounds
 
-foreign import capi unsafe "hs_BRepBuilderAPI_MakeFace.h hs_new_BRepBuilderAPI_MakeFace_fromSurfaceAndBounds" rawFromSurfaceAndBounds :: Ptr (Handle (Geom.Surface)) -> CDouble -> CDouble -> CDouble -> CDouble -> CDouble -> IO (Ptr MakeFace)
+foreign import capi unsafe "hs_BRepBuilderAPI_MakeFace.h hs_new_BRepBuilderAPI_MakeFace_fromSurfaceAndBounds" rawFromSurfaceAndBounds
+    :: Ptr (Handle (Geom.Surface))
+    -> CDouble
+    -> CDouble
+    -> CDouble
+    -> CDouble
+    -> CDouble
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr MakeFace)
 
 fromSurfaceAndBounds :: Ptr (Handle Geom.Surface) -> Double -> Double -> Double -> Double -> Double -> Acquire (Ptr MakeFace)
-fromSurfaceAndBounds surf uMin uMax vMin vMax tolerance = mkAcquire (rawFromSurfaceAndBounds surf (CDouble uMin) (CDouble uMax) (CDouble vMin) (CDouble vMax) (CDouble tolerance)) deleteMakeFace
+fromSurfaceAndBounds surf uMin uMax vMin vMax tolerance = mkAcquire (wrapException $ rawFromSurfaceAndBounds surf (CDouble uMin) (CDouble uMax) (CDouble vMin) (CDouble vMax) (CDouble tolerance)) deleteMakeFace
 
 -- fromSurfaceAndWire
 --
-foreign import capi unsafe "hs_BRepBuilderAPI_MakeFace.h hs_new_BRepBuilderAPI_MakeFace_fromSurfaceAndWire" rawFromSurfaceAndWire :: Ptr (Handle (Geom.Surface)) -> Ptr TopoDS.Wire -> CBool -> IO (Ptr MakeFace)
+foreign import capi unsafe "hs_BRepBuilderAPI_MakeFace.h hs_new_BRepBuilderAPI_MakeFace_fromSurfaceAndWire" rawFromSurfaceAndWire
+    :: Ptr (Handle (Geom.Surface))
+    -> Ptr TopoDS.Wire
+    -> CBool
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr MakeFace)
 
 fromSurfaceAndWire :: Ptr (Handle Geom.Surface) -> Ptr TopoDS.Wire -> Bool -> Acquire (Ptr MakeFace)
-fromSurfaceAndWire surf wire inside = mkAcquire (rawFromSurfaceAndWire surf wire (boolToCBool inside)) deleteMakeFace
+fromSurfaceAndWire surf wire inside = mkAcquire (wrapException $ rawFromSurfaceAndWire surf wire (boolToCBool inside)) deleteMakeFace
 
 -- fromWire
 
-foreign import capi unsafe "hs_BRepBuilderAPI_MakeFace.h hs_new_BRepBuilderAPI_MakeFace_fromWire" rawFromWire :: Ptr TopoDS.Wire -> CBool ->  IO (Ptr MakeFace)
+foreign import capi unsafe "hs_BRepBuilderAPI_MakeFace.h hs_new_BRepBuilderAPI_MakeFace_fromWire" rawFromWire
+    :: Ptr TopoDS.Wire
+    -> CBool
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr MakeFace)
 
 fromWire :: Ptr TopoDS.Wire -> Bool -> Acquire (Ptr MakeFace)
-fromWire wire onlyPlane = mkAcquire (rawFromWire wire (boolToCBool onlyPlane)) deleteMakeFace
+fromWire wire onlyPlane = mkAcquire (wrapException $ rawFromWire wire (boolToCBool onlyPlane)) deleteMakeFace
 
--- add 
-foreign import capi unsafe "hs_BRepBuilderAPI_MakeFace.h hs_BRepBuilderAPI_MakeFace_Add" add :: Ptr MakeFace -> Ptr TopoDS.Wire -> IO ()
+-- add
+foreign import capi unsafe "hs_BRepBuilderAPI_MakeFace.h hs_BRepBuilderAPI_MakeFace_Add" rawAdd
+    :: Ptr MakeFace
+    -> Ptr TopoDS.Wire
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
+
+add :: Ptr MakeFace -> Ptr TopoDS.Wire -> IO ()
+add builder wire = wrapException $ rawAdd builder wire
 
 -- isDone
 --
@@ -87,7 +125,11 @@ error :: Ptr MakeFace -> IO FaceError
 error p = toEnum . fromIntegral <$> rawError p
 
 
-foreign import capi unsafe "hs_BRepBuilderAPI_MakeFace.h hs_BRepBuilderAPI_MakeFace_Face" rawFace :: Ptr MakeFace ->  IO (Ptr TopoDS.Face)
+foreign import capi unsafe "hs_BRepBuilderAPI_MakeFace.h hs_BRepBuilderAPI_MakeFace_Face" rawFace
+    :: Ptr MakeFace
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Face)
 
 face :: Ptr MakeFace -> Acquire (Ptr TopoDS.Face)
-face builder = mkAcquire (rawFace builder) (deleteShape . upcast)
+face builder = mkAcquire (wrapException $ rawFace builder) (deleteShape . upcast)

--- a/opencascade-hs/src/OpenCascade/BRepBuilderAPI/MakePolygon.hs
+++ b/opencascade-hs/src/OpenCascade/BRepBuilderAPI/MakePolygon.hs
@@ -7,12 +7,20 @@ import qualified OpenCascade.GP as GP
 import qualified OpenCascade.TopoDS as TopoDS
 import OpenCascade.TopoDS.Internal.Destructors (deleteShape)
 import OpenCascade.Inheritance (upcast)
-import Foreign.C (CBool (..))
+import OpenCascade.Internal.Exception (wrapException)
+import Foreign.C (CBool (..), CInt)
 import Foreign.Ptr (Ptr)
 import Data.Acquire (Acquire, mkAcquire)
 import OpenCascade.Internal.Bool (boolToCBool)
 
-foreign import capi unsafe "hs_BRepBuilderAPI_MakePolygon.h hs_BRepBuilderAPI_MakePolygon_from3Pnts" rawFrom3Pnts :: Ptr GP.Pnt -> Ptr GP.Pnt -> Ptr GP.Pnt -> CBool -> IO (Ptr TopoDS.Wire)
+foreign import capi unsafe "hs_BRepBuilderAPI_MakePolygon.h hs_BRepBuilderAPI_MakePolygon_from3Pnts" rawFrom3Pnts
+    :: Ptr GP.Pnt
+    -> Ptr GP.Pnt
+    -> Ptr GP.Pnt
+    -> CBool
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Wire)
 
 from3Pnts :: Ptr GP.Pnt -> Ptr GP.Pnt -> Ptr GP.Pnt -> Bool -> Acquire (Ptr TopoDS.Wire)
-from3Pnts p1 p2 p3 close = mkAcquire (rawFrom3Pnts p1 p2 p3 (boolToCBool close)) (deleteShape . upcast)
+from3Pnts p1 p2 p3 close = mkAcquire (wrapException $ rawFrom3Pnts p1 p2 p3 (boolToCBool close)) (deleteShape . upcast)

--- a/opencascade-hs/src/OpenCascade/BRepBuilderAPI/MakeShape.hs
+++ b/opencascade-hs/src/OpenCascade/BRepBuilderAPI/MakeShape.hs
@@ -7,12 +7,25 @@ module OpenCascade.BRepBuilderAPI.MakeShape
 import OpenCascade.BRepBuilderAPI.Types
 import qualified OpenCascade.TopoDS as TopoDS
 import OpenCascade.TopoDS.Internal.Destructors (deleteShape)
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.Ptr
 import Data.Acquire 
+import Foreign.C (CInt)
 
-foreign import capi unsafe "hs_BRepBuilderAPI_MakeShape.h hs_BRepBuilderAPI_MakeShape_shape" rawShape :: Ptr MakeShape -> IO (Ptr TopoDS.Shape)
+foreign import capi unsafe "hs_BRepBuilderAPI_MakeShape.h hs_BRepBuilderAPI_MakeShape_shape" rawShape
+    :: Ptr MakeShape 
+    -> Ptr CInt 
+    -> Ptr (Ptr ()) 
+    -> IO (Ptr TopoDS.Shape)
 
 shape :: Ptr MakeShape -> Acquire (Ptr TopoDS.Shape)
-shape builder = mkAcquire (rawShape builder) (deleteShape)  
+shape builder = mkAcquire (wrapException $ rawShape builder) (deleteShape)  
 
-foreign import capi unsafe "hs_BRepBuilderAPI_MakeShape.h hs_BRepBuilderAPI_MakeShape_build" build :: Ptr MakeShape -> IO ()
+foreign import capi unsafe "hs_BRepBuilderAPI_MakeShape.h hs_BRepBuilderAPI_MakeShape_build" rawBuild
+    :: Ptr MakeShape 
+    -> Ptr CInt 
+    -> Ptr (Ptr ()) 
+    -> IO ()
+
+build :: Ptr MakeShape -> IO ()
+build builder = wrapException $ rawBuild builder

--- a/opencascade-hs/src/OpenCascade/BRepBuilderAPI/MakeSolid.hs
+++ b/opencascade-hs/src/OpenCascade/BRepBuilderAPI/MakeSolid.hs
@@ -10,8 +10,10 @@ import OpenCascade.BRepBuilderAPI.Internal.Destructors
 import qualified OpenCascade.TopoDS as TopoDS
 import OpenCascade.Inheritance (upcast)
 import OpenCascade.TopoDS.Internal.Destructors (deleteShape)
+import OpenCascade.Internal.Exception (wrapException)
+import Foreign.C (CInt)
 import Foreign.Ptr
-import Data.Acquire 
+import Data.Acquire
 
 -- new
 
@@ -20,11 +22,23 @@ foreign import capi unsafe "hs_BRepBuilderAPI_MakeSolid.h hs_new_BRepBuilderAPI_
 new :: Acquire (Ptr MakeSolid)
 new = mkAcquire rawNew deleteMakeSolid
 
--- add 
-foreign import capi unsafe "hs_BRepBuilderAPI_MakeSolid.h hs_BRepBuilderAPI_MakeSolid_add" add :: Ptr MakeSolid -> Ptr TopoDS.Shell -> IO ()
+-- add
+foreign import capi unsafe "hs_BRepBuilderAPI_MakeSolid.h hs_BRepBuilderAPI_MakeSolid_add" rawAdd
+    :: Ptr MakeSolid
+    -> Ptr TopoDS.Shell
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
 
-foreign import capi unsafe "hs_BRepBuilderAPI_MakeSolid.h hs_BRepBuilderAPI_MakeSolid_solid" rawSolid :: Ptr MakeSolid -> IO (Ptr TopoDS.Solid)
+add :: Ptr MakeSolid -> Ptr TopoDS.Shell -> IO ()
+add builder shell = wrapException $ rawAdd builder shell
+
+foreign import capi unsafe "hs_BRepBuilderAPI_MakeSolid.h hs_BRepBuilderAPI_MakeSolid_solid" rawSolid
+    :: Ptr MakeSolid
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Solid)
 
 solid :: Ptr MakeSolid -> Acquire (Ptr TopoDS.Solid)
-solid builder = mkAcquire (rawSolid builder) (deleteShape . upcast)
+solid builder = mkAcquire (wrapException $ rawSolid builder) (deleteShape . upcast)
 

--- a/opencascade-hs/src/OpenCascade/BRepBuilderAPI/MakeVertex.hs
+++ b/opencascade-hs/src/OpenCascade/BRepBuilderAPI/MakeVertex.hs
@@ -10,17 +10,27 @@ import OpenCascade.BRepBuilderAPI.Internal.Destructors (deleteMakeVertex)
 import qualified OpenCascade.GP as GP
 import qualified OpenCascade.TopoDS as TopoDS
 import qualified OpenCascade.TopoDS.Internal.Destructors as TopoDS.Destructors
+import OpenCascade.Internal.Exception (wrapException)
+import Foreign.C (CInt)
 import Foreign.Ptr (Ptr)
 import Data.Acquire (Acquire, mkAcquire)
 import OpenCascade.Inheritance (upcast)
 
-foreign import capi unsafe "hs_BRepBuilderAPI_MakeVertex.h hs_new_BRepBuilderAPI_MakeVertex_fromPnt" rawFromPnt :: Ptr GP.Pnt -> IO (Ptr MakeVertex)
+foreign import capi unsafe "hs_BRepBuilderAPI_MakeVertex.h hs_new_BRepBuilderAPI_MakeVertex_fromPnt" rawFromPnt
+    :: Ptr GP.Pnt
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr MakeVertex)
 
 fromPnt :: Ptr GP.Pnt -> Acquire (Ptr MakeVertex)
-fromPnt pnt = mkAcquire (rawFromPnt pnt) (deleteMakeVertex)
+fromPnt pnt = mkAcquire (wrapException $ rawFromPnt pnt) (deleteMakeVertex)
 
 
-foreign import capi unsafe "hs_BRepBuilderAPI_MakeVertex.h hs_BRepBuilderAPI_MakeVertex_vertex" rawVertex :: Ptr MakeVertex -> IO (Ptr TopoDS.Vertex)
+foreign import capi unsafe "hs_BRepBuilderAPI_MakeVertex.h hs_BRepBuilderAPI_MakeVertex_vertex" rawVertex
+    :: Ptr MakeVertex
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Vertex)
 
 vertex :: Ptr MakeVertex -> Acquire (Ptr TopoDS.Vertex)
-vertex builder = mkAcquire (rawVertex builder) (TopoDS.Destructors.deleteShape . upcast)
+vertex builder = mkAcquire (wrapException $ rawVertex builder) (TopoDS.Destructors.deleteShape . upcast)

--- a/opencascade-hs/src/OpenCascade/BRepBuilderAPI/MakeWire.hs
+++ b/opencascade-hs/src/OpenCascade/BRepBuilderAPI/MakeWire.hs
@@ -20,6 +20,7 @@ import qualified OpenCascade.TopoDS as TopoDS
 import qualified OpenCascade.TopoDS.Internal.Destructors as TopoDS.Destructors
 import qualified OpenCascade.TopTools as TopTools
 import OpenCascade.BRepBuilderAPI.WireError (WireError)
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.C
 import Foreign.Ptr
 import Data.Acquire 
@@ -31,33 +32,65 @@ foreign import capi unsafe "hs_BRepBuilderAPI_MakeWire.h hs_new_BRepBuilderAPI_M
 new :: Acquire (Ptr MakeWire)
 new = mkAcquire rawNew deleteMakeWire
 
--- addEdge 
+-- addEdge
 
-foreign import capi unsafe "hs_BRepBuilderAPI_MakeWire.h hs_BRepBuilderAPI_MakeWire_AddEdge" addEdge :: Ptr MakeWire -> Ptr TopoDS.Edge -> IO ()
+foreign import capi unsafe "hs_BRepBuilderAPI_MakeWire.h hs_BRepBuilderAPI_MakeWire_AddEdge" rawAddEdge
+    :: Ptr MakeWire
+    -> Ptr TopoDS.Edge
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
+
+addEdge :: Ptr MakeWire -> Ptr TopoDS.Edge -> IO ()
+addEdge builder edge = wrapException $ rawAddEdge builder edge
 
 
--- addWire 
+-- addWire
 
-foreign import capi unsafe "hs_BRepBuilderAPI_MakeWire.h hs_BRepBuilderAPI_MakeWire_AddWire" addWire :: Ptr MakeWire -> Ptr TopoDS.Wire -> IO ()
+foreign import capi unsafe "hs_BRepBuilderAPI_MakeWire.h hs_BRepBuilderAPI_MakeWire_AddWire" rawAddWire
+    :: Ptr MakeWire
+    -> Ptr TopoDS.Wire
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
+
+addWire :: Ptr MakeWire -> Ptr TopoDS.Wire -> IO ()
+addWire builder theWire = wrapException $ rawAddWire builder theWire
 
 
 -- addListOfShape
 
-foreign import capi unsafe "hs_BRepBuilderAPI_MakeWire.h hs_BRepBuilderAPI_MakeWire_AddListOfShape" addListOfShape :: Ptr MakeWire -> Ptr TopTools.ListOfShape -> IO ()
+foreign import capi unsafe "hs_BRepBuilderAPI_MakeWire.h hs_BRepBuilderAPI_MakeWire_AddListOfShape" rawAddListOfShape
+    :: Ptr MakeWire
+    -> Ptr TopTools.ListOfShape
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
+
+addListOfShape :: Ptr MakeWire -> Ptr TopTools.ListOfShape -> IO ()
+addListOfShape builder list = wrapException $ rawAddListOfShape builder list
 
 -- wire
 --
-foreign import capi unsafe "hs_BRepBuilderAPI_MakeWire.h hs_BRepBuilderAPI_MakeWire_Wire" rawWire :: Ptr MakeWire -> IO (Ptr TopoDS.Wire)
+foreign import capi unsafe "hs_BRepBuilderAPI_MakeWire.h hs_BRepBuilderAPI_MakeWire_Wire" rawWire
+    :: Ptr MakeWire
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Wire)
 
 wire :: Ptr MakeWire -> Acquire (Ptr TopoDS.Wire)
-wire builder = mkAcquire (rawWire builder) (TopoDS.Destructors.deleteShape . upcast)
+wire builder = mkAcquire (wrapException $ rawWire builder) (TopoDS.Destructors.deleteShape . upcast)
 
 -- vertex
 --
-foreign import capi unsafe "hs_BRepBuilderAPI_MakeWire.h hs_BRepBuilderAPI_MakeWire_Vertex" rawVertex :: Ptr MakeWire -> IO (Ptr TopoDS.Vertex)
+foreign import capi unsafe "hs_BRepBuilderAPI_MakeWire.h hs_BRepBuilderAPI_MakeWire_Vertex" rawVertex
+    :: Ptr MakeWire
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Vertex)
 
 vertex :: Ptr MakeWire -> Acquire (Ptr TopoDS.Vertex)
-vertex builder = mkAcquire (rawVertex builder) (TopoDS.Destructors.deleteShape . upcast)
+vertex builder = mkAcquire (wrapException $ rawVertex builder) (TopoDS.Destructors.deleteShape . upcast)
 
 -- isDone
 --

--- a/opencascade-hs/src/OpenCascade/BRepBuilderAPI/Sewing.hs
+++ b/opencascade-hs/src/OpenCascade/BRepBuilderAPI/Sewing.hs
@@ -15,6 +15,7 @@ import qualified OpenCascade.TopoDS.Types as TopoDS
 import OpenCascade.TopoDS.Internal.Destructors (deleteShape)
 import OpenCascade.BRepBuilderAPI.Internal.Destructors (deleteSewing)
 import OpenCascade.BRepBuilderAPI.Types (Sewing)
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.Ptr (Ptr)
 import Foreign.C (CBool (..), CDouble (..), CInt (..))
 import OpenCascade.Internal.Bool (boolToCBool)
@@ -26,16 +27,43 @@ foreign import capi unsafe "hs_BRepBuilderAPI_Sewing.h hs_new_BRepBuilderAPI_Sew
 new :: Double -> Bool -> Bool -> Bool -> Bool -> Acquire (Ptr Sewing)
 new tolerance opt1 opt2 opt3 opt4 = mkAcquire (rawNew (coerce tolerance) (boolToCBool opt1) (boolToCBool opt2) (boolToCBool opt3) (boolToCBool opt4)) deleteSewing
 
-foreign import capi unsafe "hs_BRepBuilderAPI_Sewing.h hs_BRepBuilderAPI_Sewing_load" load :: Ptr Sewing -> Ptr TopoDS.Shape -> IO ()
+foreign import capi unsafe "hs_BRepBuilderAPI_Sewing.h hs_BRepBuilderAPI_Sewing_load" rawLoad
+    :: Ptr Sewing
+    -> Ptr TopoDS.Shape
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
 
-foreign import capi unsafe "hs_BRepBuilderAPI_Sewing.h hs_BRepBuilderAPI_Sewing_add" add :: Ptr Sewing -> Ptr TopoDS.Shape -> IO ()
+load :: Ptr Sewing -> Ptr TopoDS.Shape -> IO ()
+load sewing shape = wrapException $ rawLoad sewing shape
 
-foreign import capi unsafe "hs_BRepBuilderAPI_Sewing.h hs_BRepBuilderAPI_Sewing_perform" perform :: Ptr Sewing -> IO ()
+foreign import capi unsafe "hs_BRepBuilderAPI_Sewing.h hs_BRepBuilderAPI_Sewing_add" rawAdd
+    :: Ptr Sewing
+    -> Ptr TopoDS.Shape
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
 
-foreign import capi unsafe "hs_BRepBuilderAPI_Sewing.h hs_BRepBuilderAPI_Sewing_sewedShape" rawSewedShape :: Ptr Sewing -> IO (Ptr TopoDS.Shape)
+add :: Ptr Sewing -> Ptr TopoDS.Shape -> IO ()
+add sewing shape = wrapException $ rawAdd sewing shape
+
+foreign import capi unsafe "hs_BRepBuilderAPI_Sewing.h hs_BRepBuilderAPI_Sewing_perform" rawPerform
+    :: Ptr Sewing
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
+
+perform :: Ptr Sewing -> IO ()
+perform sewing = wrapException $ rawPerform sewing
+
+foreign import capi unsafe "hs_BRepBuilderAPI_Sewing.h hs_BRepBuilderAPI_Sewing_sewedShape" rawSewedShape
+    :: Ptr Sewing
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Shape)
 
 sewedShape :: Ptr Sewing -> Acquire (Ptr TopoDS.Shape)
-sewedShape sewing = mkAcquire (rawSewedShape sewing) (deleteShape)
+sewedShape sewing = mkAcquire (wrapException $ rawSewedShape sewing) (deleteShape)
 
 foreign import capi unsafe "hs_BRepBuilderAPI_Sewing.h hs_BRepBuilderAPI_Sewing_nbFreeEdges" rawNbFreeEdges:: Ptr Sewing -> IO (CInt)
 

--- a/opencascade-hs/src/OpenCascade/BRepBuilderAPI/Transform.hs
+++ b/opencascade-hs/src/OpenCascade/BRepBuilderAPI/Transform.hs
@@ -7,11 +7,18 @@ import qualified OpenCascade.GP as GP
 import qualified OpenCascade.TopoDS as TopoDS
 import OpenCascade.Internal.Bool
 import qualified OpenCascade.TopoDS.Internal.Destructors as TopoDS.Destructors
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.C
 import Foreign.Ptr
-import Data.Acquire 
+import Data.Acquire
 
-foreign import capi unsafe "hs_BRepBuilderAPI_Transform.h hs_BRepBuilderAPI_Transform_transform" rawTransform :: Ptr TopoDS.Shape -> Ptr GP.Trsf -> CBool -> IO (Ptr TopoDS.Shape)
+foreign import capi unsafe "hs_BRepBuilderAPI_Transform.h hs_BRepBuilderAPI_Transform_transform" rawTransform
+    :: Ptr TopoDS.Shape
+    -> Ptr GP.Trsf
+    -> CBool
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Shape)
 
 transform :: Ptr TopoDS.Shape -> Ptr GP.Trsf -> Bool -> Acquire (Ptr TopoDS.Shape)
-transform shape trsf copy = mkAcquire (rawTransform shape trsf (boolToCBool copy)) TopoDS.Destructors.deleteShape
+transform shape trsf copy = mkAcquire (wrapException $ rawTransform shape trsf (boolToCBool copy)) TopoDS.Destructors.deleteShape

--- a/opencascade-hs/src/OpenCascade/BRepFilletAPI/MakeChamfer.hs
+++ b/opencascade-hs/src/OpenCascade/BRepFilletAPI/MakeChamfer.hs
@@ -15,23 +15,42 @@ import OpenCascade.BRepFilletAPI.Internal.Destructors (deleteMakeChamfer)
 import qualified OpenCascade.TopoDS as TopoDS
 import OpenCascade.TopoDS.Internal.Destructors (deleteShape)
 import OpenCascade.Inheritance (upcast)
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.Ptr
 import Foreign.C
 import Data.Acquire
 import Data.Coerce (coerce)
 
 
-foreign import capi unsafe "hs_BRepFilletAPI_MakeChamfer.h hs_new_BRepFilletAPI_MakeChamfer_fromShape" rawFromShape :: Ptr TopoDS.Shape -> IO (Ptr MakeChamfer)
+foreign import capi unsafe "hs_BRepFilletAPI_MakeChamfer.h hs_new_BRepFilletAPI_MakeChamfer_fromShape" rawFromShape
+    :: Ptr TopoDS.Shape
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr MakeChamfer)
 
 fromShape :: Ptr TopoDS.Shape  -> Acquire (Ptr MakeChamfer)
-fromShape shape = mkAcquire (rawFromShape shape) deleteMakeChamfer
+fromShape shape = mkAcquire (wrapException $ rawFromShape shape) deleteMakeChamfer
 
-foreign import capi unsafe "hs_BRepFilletAPI_MakeChamfer.h hs_BRepFilletAPI_MakeChamfer_addEdge" addEdge :: Ptr MakeChamfer -> Ptr TopoDS.Edge -> IO ()
+foreign import capi unsafe "hs_BRepFilletAPI_MakeChamfer.h hs_BRepFilletAPI_MakeChamfer_addEdge" rawAddEdge
+    :: Ptr MakeChamfer
+    -> Ptr TopoDS.Edge
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
 
-foreign import capi unsafe "hs_BRepFilletAPI_MakeChamfer.h hs_BRepFilletAPI_MakeChamfer_addEdgeWithDistance" rawAddEdgeWithDistance :: Ptr MakeChamfer -> CDouble -> Ptr TopoDS.Edge -> IO ()
+addEdge :: Ptr MakeChamfer -> Ptr TopoDS.Edge -> IO ()
+addEdge builder e = wrapException $ rawAddEdge builder e
+
+foreign import capi unsafe "hs_BRepFilletAPI_MakeChamfer.h hs_BRepFilletAPI_MakeChamfer_addEdgeWithDistance" rawAddEdgeWithDistance
+    :: Ptr MakeChamfer
+    -> CDouble
+    -> Ptr TopoDS.Edge
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
 
 addEdgeWithDistance :: Ptr MakeChamfer -> Double -> Ptr TopoDS.Edge -> IO ()
-addEdgeWithDistance = coerce rawAddEdgeWithDistance
+addEdgeWithDistance builder d e = wrapException $ rawAddEdgeWithDistance builder (coerce d) e
 
 foreign import capi unsafe "hs_BRepFilletAPI_MakeChamfer.h hs_BRepFilletAPI_MakeChamfer_reset" reset :: Ptr MakeChamfer -> IO ()
 
@@ -40,9 +59,23 @@ foreign import capi unsafe "hs_BRepFilletAPI_MakeChamfer.h hs_BRepFilletAPI_Make
 nbEdges :: Ptr MakeChamfer -> Int -> IO Int
 nbEdges builder index = fromIntegral <$> rawNbEdges builder (fromIntegral index)
 
-foreign import capi unsafe "hs_BRepFilletAPI_MakeChamfer.h hs_BRepFilletAPI_MakeChamfer_edge" rawEdge :: Ptr MakeChamfer -> CInt -> CInt -> IO (Ptr TopoDS.Edge)
+foreign import capi unsafe "hs_BRepFilletAPI_MakeChamfer.h hs_BRepFilletAPI_MakeChamfer_edge" rawEdge
+    :: Ptr MakeChamfer
+    -> CInt
+    -> CInt
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Edge)
 
 edge :: Ptr MakeChamfer -> Int -> Int -> Acquire (Ptr TopoDS.Edge)
-edge builder contourIndex edgeIndex = mkAcquire (rawEdge builder (fromIntegral contourIndex) (fromIntegral edgeIndex)) (deleteShape . upcast)
+edge builder contourIndex edgeIndex = mkAcquire (wrapException $ rawEdge builder (fromIntegral contourIndex) (fromIntegral edgeIndex)) (deleteShape . upcast)
 
-foreign import capi unsafe "hs_BRepFilletAPI_MakeChamfer.h hs_BRepFilletAPI_MakeChamfer_remove" remove :: Ptr MakeChamfer -> Ptr TopoDS.Edge -> IO ()
+foreign import capi unsafe "hs_BRepFilletAPI_MakeChamfer.h hs_BRepFilletAPI_MakeChamfer_remove" rawRemove
+    :: Ptr MakeChamfer
+    -> Ptr TopoDS.Edge
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
+
+remove :: Ptr MakeChamfer -> Ptr TopoDS.Edge -> IO ()
+remove builder e = wrapException $ rawRemove builder e

--- a/opencascade-hs/src/OpenCascade/BRepFilletAPI/MakeFillet.hs
+++ b/opencascade-hs/src/OpenCascade/BRepFilletAPI/MakeFillet.hs
@@ -18,28 +18,54 @@ import OpenCascade.BRepFilletAPI.Internal.Destructors (deleteMakeFillet)
 import qualified OpenCascade.TopoDS as TopoDS
 import OpenCascade.TopoDS.Internal.Destructors (deleteShape)
 import OpenCascade.Inheritance (upcast)
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.Ptr
 import Foreign.C
 import Data.Acquire
 import Data.Coerce (coerce)
 
 
-foreign import capi unsafe "hs_BRepFilletAPI_MakeFillet.h hs_new_BRepFilletAPI_MakeFillet_fromShape" rawFromShape :: Ptr TopoDS.Shape -> IO (Ptr MakeFillet)
+foreign import capi unsafe "hs_BRepFilletAPI_MakeFillet.h hs_new_BRepFilletAPI_MakeFillet_fromShape" rawFromShape
+    :: Ptr TopoDS.Shape
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr MakeFillet)
 
 fromShape :: Ptr TopoDS.Shape  -> Acquire (Ptr MakeFillet)
-fromShape shape = mkAcquire (rawFromShape shape) deleteMakeFillet
+fromShape shape = mkAcquire (wrapException $ rawFromShape shape) deleteMakeFillet
 
-foreign import capi unsafe "hs_BRepFilletAPI_MakeFillet.h hs_BRepFilletAPI_MakeFillet_addEdge" addEdge :: Ptr MakeFillet -> Ptr TopoDS.Edge -> IO ()
+foreign import capi unsafe "hs_BRepFilletAPI_MakeFillet.h hs_BRepFilletAPI_MakeFillet_addEdge" rawAddEdge
+    :: Ptr MakeFillet
+    -> Ptr TopoDS.Edge
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
 
-foreign import capi unsafe "hs_BRepFilletAPI_MakeFillet.h hs_BRepFilletAPI_MakeFillet_addEdgeWithRadius" rawAddEdgeWithRadius :: Ptr MakeFillet -> CDouble -> Ptr TopoDS.Edge -> IO ()
+addEdge :: Ptr MakeFillet -> Ptr TopoDS.Edge -> IO ()
+addEdge builder e = wrapException $ rawAddEdge builder e
+
+foreign import capi unsafe "hs_BRepFilletAPI_MakeFillet.h hs_BRepFilletAPI_MakeFillet_addEdgeWithRadius" rawAddEdgeWithRadius
+    :: Ptr MakeFillet
+    -> CDouble
+    -> Ptr TopoDS.Edge
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
 
 addEdgeWithRadius :: Ptr MakeFillet -> Double -> Ptr TopoDS.Edge -> IO ()
-addEdgeWithRadius = coerce rawAddEdgeWithRadius
+addEdgeWithRadius builder r e = wrapException $ rawAddEdgeWithRadius builder (coerce r) e
 
-foreign import capi unsafe "hs_BRepFilletAPI_MakeFillet.h hs_BRepFilletAPI_MakeFillet_addEdgeWithTwoRadiuses" rawAddEdgeWithTwoRadiuses :: Ptr MakeFillet -> CDouble -> CDouble -> Ptr TopoDS.Edge -> IO ()
+foreign import capi unsafe "hs_BRepFilletAPI_MakeFillet.h hs_BRepFilletAPI_MakeFillet_addEdgeWithTwoRadiuses" rawAddEdgeWithTwoRadiuses
+    :: Ptr MakeFillet
+    -> CDouble
+    -> CDouble
+    -> Ptr TopoDS.Edge
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
 
 addEdgeWithTwoRadiuses :: Ptr MakeFillet -> Double -> Double -> Ptr TopoDS.Edge -> IO ()
-addEdgeWithTwoRadiuses = coerce rawAddEdgeWithTwoRadiuses
+addEdgeWithTwoRadiuses builder r1 r2 e = wrapException $ rawAddEdgeWithTwoRadiuses builder (coerce r1) (coerce r2) e
 
 foreign import capi unsafe "hs_BRepFilletAPI_MakeFillet.h hs_BRepFilletAPI_MakeFillet_reset" reset :: Ptr MakeFillet -> IO ()
 
@@ -58,9 +84,23 @@ foreign import capi unsafe "hs_BRepFilletAPI_MakeFillet.h hs_BRepFilletAPI_MakeF
 nbEdges :: Ptr MakeFillet -> Int -> IO Int
 nbEdges builder index = fromIntegral <$> rawNbEdges builder (fromIntegral index)
 
-foreign import capi unsafe "hs_BRepFilletAPI_MakeFillet.h hs_BRepFilletAPI_MakeFillet_edge" rawEdge :: Ptr MakeFillet -> CInt -> CInt -> IO (Ptr TopoDS.Edge)
+foreign import capi unsafe "hs_BRepFilletAPI_MakeFillet.h hs_BRepFilletAPI_MakeFillet_edge" rawEdge
+    :: Ptr MakeFillet
+    -> CInt
+    -> CInt
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Edge)
 
 edge :: Ptr MakeFillet -> Int -> Int -> Acquire (Ptr TopoDS.Edge)
-edge builder contourIndex edgeIndex = mkAcquire (rawEdge builder (fromIntegral contourIndex) (fromIntegral edgeIndex)) (deleteShape . upcast)
+edge builder contourIndex edgeIndex = mkAcquire (wrapException $ rawEdge builder (fromIntegral contourIndex) (fromIntegral edgeIndex)) (deleteShape . upcast)
 
-foreign import capi unsafe "hs_BRepFilletAPI_MakeFillet.h hs_BRepFilletAPI_MakeFillet_remove" remove :: Ptr MakeFillet -> Ptr TopoDS.Edge -> IO ()
+foreign import capi unsafe "hs_BRepFilletAPI_MakeFillet.h hs_BRepFilletAPI_MakeFillet_remove" rawRemove
+    :: Ptr MakeFillet
+    -> Ptr TopoDS.Edge
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
+
+remove :: Ptr MakeFillet -> Ptr TopoDS.Edge -> IO ()
+remove builder e = wrapException $ rawRemove builder e

--- a/opencascade-hs/src/OpenCascade/BRepGProp.hs
+++ b/opencascade-hs/src/OpenCascade/BRepGProp.hs
@@ -8,26 +8,49 @@ module OpenCascade.BRepGProp
 import OpenCascade.TopoDS.Types (Shape)
 import OpenCascade.GProp.Types (GProps)
 import Foreign.Ptr (Ptr)
-import Foreign.C (CBool (..))
+import Foreign.C (CBool (..), CInt)
 import OpenCascade.Internal.Bool (boolToCBool)
+import OpenCascade.Internal.Exception (wrapException)
 
-foreign import capi unsafe "hs_BRepGProp.h hs_BRepGProp_VolumeProperties" rawVolumeProperties :: Ptr Shape -> Ptr GProps -> CBool -> CBool -> CBool -> IO ()
+foreign import capi unsafe "hs_BRepGProp.h hs_BRepGProp_VolumeProperties" rawVolumeProperties
+    :: Ptr Shape
+    -> Ptr GProps
+    -> CBool
+    -> CBool
+    -> CBool
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
 
 volumeProperties :: Ptr Shape -> Ptr GProps -> Bool -> Bool -> Bool -> IO ()
 volumeProperties shape props onlyClosed skipShared useTriangulation =
-    rawVolumeProperties shape props (boolToCBool onlyClosed) (boolToCBool skipShared) (boolToCBool useTriangulation)
+    wrapException $ rawVolumeProperties shape props (boolToCBool onlyClosed) (boolToCBool skipShared) (boolToCBool useTriangulation)
 
-foreign import capi unsafe "hs_BRepGProp.h hs_BRepGProp_SurfaceProperties" rawSurfaceProperties :: Ptr Shape -> Ptr GProps -> CBool -> CBool -> IO ()
+foreign import capi unsafe "hs_BRepGProp.h hs_BRepGProp_SurfaceProperties" rawSurfaceProperties
+    :: Ptr Shape
+    -> Ptr GProps
+    -> CBool
+    -> CBool
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
 
 surfaceProperties :: Ptr Shape -> Ptr GProps -> Bool -> Bool -> IO ()
 surfaceProperties shape props skipShared useTriangulation =
-    rawSurfaceProperties shape props (boolToCBool skipShared) (boolToCBool useTriangulation)
+    wrapException $ rawSurfaceProperties shape props (boolToCBool skipShared) (boolToCBool useTriangulation)
 
-    
-foreign import capi unsafe "hs_BRepGProp.h hs_BRepGProp_LinearProperties" rawLinearProperties :: Ptr Shape -> Ptr GProps -> CBool -> CBool -> IO ()
+
+foreign import capi unsafe "hs_BRepGProp.h hs_BRepGProp_LinearProperties" rawLinearProperties
+    :: Ptr Shape
+    -> Ptr GProps
+    -> CBool
+    -> CBool
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
 
 linearProperties :: Ptr Shape -> Ptr GProps -> Bool -> Bool -> IO ()
 linearProperties shape props skipShared useTriangulation =
-    rawLinearProperties shape props (boolToCBool skipShared) (boolToCBool useTriangulation)
+    wrapException $ rawLinearProperties shape props (boolToCBool skipShared) (boolToCBool useTriangulation)
  
  

--- a/opencascade-hs/src/OpenCascade/BRepLib.hs
+++ b/opencascade-hs/src/OpenCascade/BRepLib.hs
@@ -9,17 +9,30 @@ import qualified OpenCascade.GeomAbs.Shape as GeomAbs.Shape
 import Foreign.Ptr (Ptr)
 import Foreign.C (CBool (..), CDouble (..), CInt (..))
 import OpenCascade.Internal.Bool (cBoolToBool)
+import OpenCascade.Internal.Exception (wrapException)
 import Data.Coerce (coerce)
 
-foreign import capi unsafe "hs_BRepLib.h hs_BRepLib_orientClosedSolid" rawOrientClosedSolid ::  Ptr Solid -> IO (CBool)
+foreign import capi unsafe "hs_BRepLib.h hs_BRepLib_orientClosedSolid" rawOrientClosedSolid
+    :: Ptr Solid
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (CBool)
 
 orientClosedSolid :: Ptr Solid -> IO Bool
-orientClosedSolid s = cBoolToBool <$> rawOrientClosedSolid s
+orientClosedSolid s = cBoolToBool <$> wrapException (rawOrientClosedSolid s)
 
 
-foreign import capi unsafe "hs_BRepLib.h hs_BRepLib_buildCurve3d" rawBuildCurve3d ::  Ptr Edge -> CDouble -> CInt -> CInt -> CInt -> IO CBool
+foreign import capi unsafe "hs_BRepLib.h hs_BRepLib_buildCurve3d" rawBuildCurve3d
+    :: Ptr Edge
+    -> CDouble
+    -> CInt
+    -> CInt
+    -> CInt
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO CBool
 
 buildCurve3d :: Ptr Edge -> Double -> GeomAbs.Shape.Shape -> Int -> Int -> IO Bool
-buildCurve3d edge tolerance continuity maxDegree maxSegment = 
-    cBoolToBool <$> rawBuildCurve3d edge (coerce tolerance) (fromIntegral . fromEnum $ continuity) (fromIntegral maxDegree) (fromIntegral maxSegment)
+buildCurve3d edge tolerance continuity maxDegree maxSegment =
+    cBoolToBool <$> wrapException (rawBuildCurve3d edge (coerce tolerance) (fromIntegral . fromEnum $ continuity) (fromIntegral maxDegree) (fromIntegral maxSegment))
 

--- a/opencascade-hs/src/OpenCascade/BRepMesh/IncrementalMesh.hs
+++ b/opencascade-hs/src/OpenCascade/BRepMesh/IncrementalMesh.hs
@@ -7,14 +7,28 @@ module OpenCascade.BRepMesh.IncrementalMesh
 import OpenCascade.BRepMesh.Types (IncrementalMesh)
 import OpenCascade.BRepMesh.Internal.Destructors (deleteIncrementalMesh)
 import qualified OpenCascade.TopoDS as TopoDS
+import OpenCascade.Internal.Exception (wrapException)
+import Foreign.C (CInt)
 import Foreign.Ptr
 import Data.Acquire
 import Data.Coerce (coerce)
 
 
-foreign import capi unsafe "hs_BRepMesh_IncrementalMesh.h hs_BRepMesh_IncrementalMesh_fromShapeAndLinDeflection" rawFromShapeAndLinDeflection :: Ptr TopoDS.Shape -> Double ->  IO (Ptr IncrementalMesh)
+foreign import capi unsafe "hs_BRepMesh_IncrementalMesh.h hs_BRepMesh_IncrementalMesh_fromShapeAndLinDeflection" rawFromShapeAndLinDeflection
+    :: Ptr TopoDS.Shape
+    -> Double
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr IncrementalMesh)
 
 fromShapeAndLinDeflection :: Ptr TopoDS.Shape -> Double -> Acquire (Ptr IncrementalMesh)
-fromShapeAndLinDeflection shape linDeflection = mkAcquire (rawFromShapeAndLinDeflection shape (coerce linDeflection)) deleteIncrementalMesh
+fromShapeAndLinDeflection shape linDeflection = mkAcquire (wrapException $ rawFromShapeAndLinDeflection shape (coerce linDeflection)) deleteIncrementalMesh
 
-foreign import capi unsafe "hs_BRepMesh_IncrementalMesh.h hs_BRepMesh_IncrementalMesh_Perform" perform :: Ptr IncrementalMesh -> IO ()
+foreign import capi unsafe "hs_BRepMesh_IncrementalMesh.h hs_BRepMesh_IncrementalMesh_Perform" rawPerform
+    :: Ptr IncrementalMesh
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
+
+perform :: Ptr IncrementalMesh -> IO ()
+perform mesh = wrapException $ rawPerform mesh

--- a/opencascade-hs/src/OpenCascade/BRepOffsetAPI/MakeOffsetShape.hs
+++ b/opencascade-hs/src/OpenCascade/BRepOffsetAPI/MakeOffsetShape.hs
@@ -23,11 +23,16 @@ foreign import capi unsafe "hs_BRepOffsetAPI_MakeOffsetShape.h hs_new_BRepOffset
 new :: Acquire (Ptr MakeOffsetShape)
 new = mkAcquire rawNew deleteMakeOffsetShape
 
-foreign import capi unsafe "hs_BRepOffsetAPI_MakeOffsetShape.h hs_BRepOffsetAPI_MakeOffsetShape_performBySimple" rawPerformBySimple :: Ptr MakeOffsetShape -> Ptr TopoDS.Shape -> CDouble -> IO ()
+foreign import capi unsafe "hs_BRepOffsetAPI_MakeOffsetShape.h hs_BRepOffsetAPI_MakeOffsetShape_performBySimple" rawPerformBySimple 
+    :: Ptr MakeOffsetShape 
+    -> Ptr TopoDS.Shape
+    -> CDouble
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
  
 performBySimple :: Ptr MakeOffsetShape -> Ptr TopoDS.Shape -> Double -> IO ()
-performBySimple = coerce rawPerformBySimple
-
+performBySimple builder shape offset = wrapException $ rawPerformBySimple builder shape (coerce offset)
 
 foreign import capi unsafe "hs_BRepOffsetAPI_MakeOffsetShape.h hs_BRepOffsetAPI_MakeOffsetShape_performByJoin" rawPerformByJoin 
     :: Ptr MakeOffsetShape 

--- a/opencascade-hs/src/OpenCascade/BRepOffsetAPI/MakeOffsetShape.hs
+++ b/opencascade-hs/src/OpenCascade/BRepOffsetAPI/MakeOffsetShape.hs
@@ -16,6 +16,7 @@ import Data.Coerce (coerce)
 import qualified OpenCascade.BRepOffset.Mode as BRepOffset.Mode
 import qualified OpenCascade.GeomAbs.JoinType as GeomAbs.JoinType
 import OpenCascade.Internal.Bool (boolToCBool)
+import OpenCascade.Internal.Exception (wrapException)
 
 foreign import capi unsafe "hs_BRepOffsetAPI_MakeOffsetShape.h hs_new_BRepOffsetAPI_MakeOffsetShape" rawNew :: IO (Ptr MakeOffsetShape)
 
@@ -28,10 +29,22 @@ performBySimple :: Ptr MakeOffsetShape -> Ptr TopoDS.Shape -> Double -> IO ()
 performBySimple = coerce rawPerformBySimple
 
 
-foreign import capi unsafe "hs_BRepOffsetAPI_MakeOffsetShape.h hs_BRepOffsetAPI_MakeOffsetShape_performByJoin" rawPerformByJoin :: Ptr MakeOffsetShape -> Ptr TopoDS.Shape -> CDouble -> CDouble -> CInt -> CBool -> CBool -> CInt -> CBool -> IO ()
+foreign import capi unsafe "hs_BRepOffsetAPI_MakeOffsetShape.h hs_BRepOffsetAPI_MakeOffsetShape_performByJoin" rawPerformByJoin 
+    :: Ptr MakeOffsetShape 
+    -> Ptr TopoDS.Shape 
+    -> CDouble 
+    -> CDouble 
+    -> CInt 
+    -> CBool
+    -> CBool
+    -> CInt
+    -> CBool
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
 
 -- |  builder, shape, value, tol, mode intersection, selfInter, join, removeIntEdges
 performByJoin :: Ptr MakeOffsetShape -> Ptr TopoDS.Shape -> Double -> Double -> BRepOffset.Mode.Mode -> Bool -> Bool -> GeomAbs.JoinType.JoinType -> Bool -> IO ()
 performByJoin builder shape value tol mode intersection selfInter join removeIntEdges =
-    rawPerformByJoin builder shape (coerce value) (coerce tol) (fromIntegral $ fromEnum mode) (boolToCBool intersection) (boolToCBool selfInter) (fromIntegral . fromEnum $ join) (boolToCBool removeIntEdges)
+    wrapException $ rawPerformByJoin builder shape (coerce value) (coerce tol) (fromIntegral $ fromEnum mode) (boolToCBool intersection) (boolToCBool selfInter) (fromIntegral . fromEnum $ join) (boolToCBool removeIntEdges)
 

--- a/opencascade-hs/src/OpenCascade/BRepOffsetAPI/MakePipe.hs
+++ b/opencascade-hs/src/OpenCascade/BRepOffsetAPI/MakePipe.hs
@@ -9,17 +9,31 @@ import OpenCascade.BRepOffsetAPI.Types (MakePipe)
 import OpenCascade.BRepOffsetAPI.Internal.Destructors (deleteMakePipe)
 import qualified OpenCascade.TopoDS as TopoDS
 import qualified OpenCascade.GeomFill as GeomFill
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.Ptr
 import Foreign.C (CBool (..), CInt (..))
 import OpenCascade.Internal.Bool (boolToCBool)
 import Data.Acquire
 
-foreign import capi unsafe "hs_BRepOffsetAPI_MakePipe.h hs_new_BRepOffsetAPI_MakePipe_fromWireAndShape" rawFromWireAndShape :: Ptr TopoDS.Wire -> Ptr TopoDS.Shape -> IO (Ptr MakePipe)
+foreign import capi unsafe "hs_BRepOffsetAPI_MakePipe.h hs_new_BRepOffsetAPI_MakePipe_fromWireAndShape" rawFromWireAndShape
+    :: Ptr TopoDS.Wire
+    -> Ptr TopoDS.Shape
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr MakePipe)
 
 fromWireAndShape :: Ptr TopoDS.Wire -> Ptr TopoDS.Shape -> Acquire (Ptr MakePipe)
-fromWireAndShape wire profile = mkAcquire (rawFromWireAndShape wire profile) deleteMakePipe
+fromWireAndShape wire profile = mkAcquire (wrapException $ rawFromWireAndShape wire profile) deleteMakePipe
 
-foreign import capi unsafe "hs_BRepOffsetAPI_MakePipe.h hs_new_BRepOffsetAPI_MakePipe_fromWireShapeTrihedronModeAndForceC1" rawFromWireShapeTrihedronModeAndForceC1 :: Ptr TopoDS.Wire -> Ptr TopoDS.Shape -> CInt -> CBool -> IO (Ptr MakePipe)
+foreign import capi unsafe "hs_BRepOffsetAPI_MakePipe.h hs_new_BRepOffsetAPI_MakePipe_fromWireShapeTrihedronModeAndForceC1" rawFromWireShapeTrihedronModeAndForceC1
+    :: Ptr TopoDS.Wire
+    -> Ptr TopoDS.Shape
+    -> CInt
+    -> CBool
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr MakePipe)
+
 fromWireShapeTrihedronModeAndForceC1 :: Ptr TopoDS.Wire -> Ptr TopoDS.Shape -> GeomFill.Trihedron -> Bool -> Acquire (Ptr MakePipe)
 fromWireShapeTrihedronModeAndForceC1 wire profile trihedronMode forceC1 =
-     mkAcquire (rawFromWireShapeTrihedronModeAndForceC1 wire profile ((fromIntegral . fromEnum $ trihedronMode)) (boolToCBool forceC1)) deleteMakePipe
+     mkAcquire (wrapException $ rawFromWireShapeTrihedronModeAndForceC1 wire profile ((fromIntegral . fromEnum $ trihedronMode)) (boolToCBool forceC1)) deleteMakePipe

--- a/opencascade-hs/src/OpenCascade/BRepOffsetAPI/ThruSections.hs
+++ b/opencascade-hs/src/OpenCascade/BRepOffsetAPI/ThruSections.hs
@@ -10,8 +10,9 @@ module OpenCascade.BRepOffsetAPI.ThruSections
 import OpenCascade.BRepOffsetAPI.Types (ThruSections)
 import OpenCascade.BRepOffsetAPI.Internal.Destructors (deleteThruSections)
 import qualified OpenCascade.TopoDS as TopoDS
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.Ptr
-import Foreign.C (CBool (..), CDouble (..))
+import Foreign.C (CBool (..), CDouble (..), CInt)
 import Data.Acquire
 import OpenCascade.Internal.Bool (boolToCBool)
 import Data.Coerce (coerce)
@@ -22,6 +23,22 @@ foreign import capi unsafe "hs_BRepOffsetAPI_ThruSections.h hs_new_BRepOffsetAPI
 new :: Bool -> Bool -> Double -> Acquire (Ptr ThruSections)
 new makeSolid ruled precision = mkAcquire (rawNew (boolToCBool makeSolid) (boolToCBool ruled) (coerce precision)) deleteThruSections
 
-foreign import capi unsafe "hs_BRepOffsetAPI_ThruSections.h hs_BRepOffsetAPI_ThruSections_addWire" addWire :: Ptr ThruSections -> Ptr TopoDS.Wire -> IO ()
+foreign import capi unsafe "hs_BRepOffsetAPI_ThruSections.h hs_BRepOffsetAPI_ThruSections_addWire" rawAddWire
+    :: Ptr ThruSections
+    -> Ptr TopoDS.Wire
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
 
-foreign import capi unsafe "hs_BRepOffsetAPI_ThruSections.h hs_BRepOffsetAPI_ThruSections_addVertex" addVertex :: Ptr ThruSections -> Ptr TopoDS.Vertex -> IO ()
+addWire :: Ptr ThruSections -> Ptr TopoDS.Wire -> IO ()
+addWire thruSections wire = wrapException $ rawAddWire thruSections wire
+
+foreign import capi unsafe "hs_BRepOffsetAPI_ThruSections.h hs_BRepOffsetAPI_ThruSections_addVertex" rawAddVertex
+    :: Ptr ThruSections
+    -> Ptr TopoDS.Vertex
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
+
+addVertex :: Ptr ThruSections -> Ptr TopoDS.Vertex -> IO ()
+addVertex thruSections vertex = wrapException $ rawAddVertex thruSections vertex

--- a/opencascade-hs/src/OpenCascade/BRepPrimAPI/MakeBox.hs
+++ b/opencascade-hs/src/OpenCascade/BRepPrimAPI/MakeBox.hs
@@ -10,30 +10,45 @@ import OpenCascade.BRepPrimAPI.Internal.Destructors (deleteMakeBox)
 import qualified OpenCascade.TopoDS as TopoDS
 import OpenCascade.TopoDS.Internal.Destructors (deleteShape)
 import qualified OpenCascade.GP as GP
+import OpenCascade.Internal.Exception (wrapException)
+import Foreign.C (CInt)
 import Foreign.Ptr
 import Data.Acquire
 
 -- new
 
-foreign import capi unsafe "hs_BRepPrimAPI_MakeBox.h hs_new_BRepPrimAPI_MakeBox_fromPnts" rawFromPnts :: Ptr GP.Pnt -> Ptr GP.Pnt ->  IO (Ptr MakeBox)
+foreign import capi unsafe "hs_BRepPrimAPI_MakeBox.h hs_new_BRepPrimAPI_MakeBox_fromPnts" rawFromPnts
+    :: Ptr GP.Pnt
+    -> Ptr GP.Pnt
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr MakeBox)
 
 fromPnts :: Ptr GP.Pnt -> Ptr GP.Pnt -> Acquire (Ptr MakeBox)
-fromPnts a b = mkAcquire (rawFromPnts a b) deleteMakeBox
+fromPnts a b = mkAcquire (wrapException $ rawFromPnts a b) deleteMakeBox
 
--- solid 
+-- solid
 
 
-foreign import capi unsafe "hs_BRepPrimAPI_MakeBox.h hs_BRepPrimAPI_MakeBox_Solid" rawSolid :: Ptr MakeBox ->  IO (Ptr TopoDS.Solid)
+foreign import capi unsafe "hs_BRepPrimAPI_MakeBox.h hs_BRepPrimAPI_MakeBox_Solid" rawSolid
+    :: Ptr MakeBox
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Solid)
 
 solid :: Ptr MakeBox -> Acquire (Ptr TopoDS.Solid)
-solid builder = mkAcquire (rawSolid builder) (deleteShape . castPtr)
+solid builder = mkAcquire (wrapException $ rawSolid builder) (deleteShape . castPtr)
 
 -- shell
 
-foreign import capi unsafe "hs_BRepPrimAPI_MakeBox.h hs_BRepPrimAPI_MakeBox_Shell" rawShell :: Ptr MakeBox ->  IO (Ptr TopoDS.Shell)
+foreign import capi unsafe "hs_BRepPrimAPI_MakeBox.h hs_BRepPrimAPI_MakeBox_Shell" rawShell
+    :: Ptr MakeBox
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Shell)
 
 shell:: Ptr MakeBox -> Acquire (Ptr TopoDS.Shell)
-shell builder = mkAcquire (rawShell builder) (deleteShape . castPtr)
+shell builder = mkAcquire (wrapException $ rawShell builder) (deleteShape . castPtr)
 
 
 

--- a/opencascade-hs/src/OpenCascade/BRepPrimAPI/MakeCone.hs
+++ b/opencascade-hs/src/OpenCascade/BRepPrimAPI/MakeCone.hs
@@ -5,12 +5,19 @@ module OpenCascade.BRepPrimAPI.MakeCone
 
 import qualified OpenCascade.TopoDS as TopoDS
 import qualified OpenCascade.TopoDS.Internal.Destructors as TopoDS.Destructors
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.C
 import Foreign.Ptr
-import Data.Acquire 
+import Data.Acquire
 import Data.Coerce (coerce)
 
-foreign import capi unsafe "hs_BRepPrimAPI_MakeCone.h hs_BRepPrimAPI_MakeCone_fromTwoRadiiAndHeight" rawFromTwoRadiiAndHeight :: CDouble -> CDouble -> CDouble -> IO (Ptr TopoDS.Solid)
+foreign import capi unsafe "hs_BRepPrimAPI_MakeCone.h hs_BRepPrimAPI_MakeCone_fromTwoRadiiAndHeight" rawFromTwoRadiiAndHeight
+    :: CDouble
+    -> CDouble
+    -> CDouble
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Solid)
 
 fromTwoRadiiAndHeight :: Double -> Double -> Double -> Acquire (Ptr TopoDS.Solid)
-fromTwoRadiiAndHeight r1 r2 h = mkAcquire ((coerce rawFromTwoRadiiAndHeight) r1 r2 h) (TopoDS.Destructors.deleteShape . castPtr)
+fromTwoRadiiAndHeight r1 r2 h = mkAcquire (wrapException $ rawFromTwoRadiiAndHeight (coerce r1) (coerce r2) (coerce h)) (TopoDS.Destructors.deleteShape . castPtr)

--- a/opencascade-hs/src/OpenCascade/BRepPrimAPI/MakeCylinder.hs
+++ b/opencascade-hs/src/OpenCascade/BRepPrimAPI/MakeCylinder.hs
@@ -5,12 +5,18 @@ module OpenCascade.BRepPrimAPI.MakeCylinder
 
 import qualified OpenCascade.TopoDS as TopoDS
 import qualified OpenCascade.TopoDS.Internal.Destructors as TopoDS.Destructors
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.C
 import Foreign.Ptr
-import Data.Acquire 
+import Data.Acquire
 import Data.Coerce (coerce)
 
-foreign import capi unsafe "hs_BRepPrimAPI_MakeCylinder.h hs_BRepPrimAPI_MakeCylinder_fromRadiusAndHeight" rawFromRadiusAndHeight :: CDouble -> CDouble -> IO (Ptr TopoDS.Solid)
+foreign import capi unsafe "hs_BRepPrimAPI_MakeCylinder.h hs_BRepPrimAPI_MakeCylinder_fromRadiusAndHeight" rawFromRadiusAndHeight
+    :: CDouble
+    -> CDouble
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Solid)
 
 fromRadiusAndHeight :: Double -> Double -> Acquire (Ptr TopoDS.Solid)
-fromRadiusAndHeight r h = mkAcquire (rawFromRadiusAndHeight (coerce r) (coerce h)) (TopoDS.Destructors.deleteShape . castPtr)
+fromRadiusAndHeight r h = mkAcquire (wrapException $ rawFromRadiusAndHeight (coerce r) (coerce h)) (TopoDS.Destructors.deleteShape . castPtr)

--- a/opencascade-hs/src/OpenCascade/BRepPrimAPI/MakePrism.hs
+++ b/opencascade-hs/src/OpenCascade/BRepPrimAPI/MakePrism.hs
@@ -11,14 +11,36 @@ import qualified OpenCascade.TopoDS.Internal.Destructors as TopoDS.Destructors
 import Foreign.C
 import Foreign.Ptr
 import Data.Acquire 
+import OpenCascade.Internal.Exception (wrapException)
 
-foreign import capi unsafe "hs_BRepPrimAPI_MakePrism.h hs_BRepPrimAPI_MakePrism_fromVec" rawFromVec :: Ptr TopoDS.Shape -> Ptr GP.Vec -> CBool -> CBool -> IO (Ptr TopoDS.Shape)
+foreign import capi unsafe "hs_BRepPrimAPI_MakePrism.h hs_BRepPrimAPI_MakePrism_fromVec" rawFromVec 
+    :: Ptr TopoDS.Shape 
+    -> Ptr GP.Vec 
+    -> CBool 
+    -> CBool
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Shape)
 
 fromVec :: Ptr TopoDS.Shape -> Ptr GP.Vec -> Bool -> Bool -> Acquire (Ptr TopoDS.Shape)
-fromVec shape vec copy canonize = mkAcquire (rawFromVec shape vec (boolToCBool copy) (boolToCBool canonize)) TopoDS.Destructors.deleteShape
+fromVec shape vec copy canonize = 
+    mkAcquire 
+        (wrapException $ rawFromVec shape vec (boolToCBool copy) (boolToCBool canonize)) 
+        TopoDS.Destructors.deleteShape
 
 
-foreign import capi unsafe "hs_BRepPrimAPI_MakePrism.h hs_BRepPrimAPI_MakePrism_fromDir" rawFromDir :: Ptr TopoDS.Shape -> Ptr GP.Dir -> CBool -> CBool -> CBool -> IO (Ptr TopoDS.Shape)
+foreign import capi unsafe "hs_BRepPrimAPI_MakePrism.h hs_BRepPrimAPI_MakePrism_fromDir" rawFromDir
+    :: Ptr TopoDS.Shape 
+    -> Ptr GP.Dir 
+    -> CBool 
+    -> CBool 
+    -> CBool
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Shape)
 
 fromDir :: Ptr TopoDS.Shape -> Ptr GP.Dir -> Bool -> Bool -> Bool -> Acquire (Ptr TopoDS.Shape)
-fromDir shape dir inf copy canonize = mkAcquire (rawFromDir shape dir (boolToCBool inf) (boolToCBool copy) (boolToCBool canonize)) TopoDS.Destructors.deleteShape
+fromDir shape dir inf copy canonize = 
+    mkAcquire 
+        (wrapException $ rawFromDir shape dir (boolToCBool inf) (boolToCBool copy) (boolToCBool canonize)) 
+        TopoDS.Destructors.deleteShape

--- a/opencascade-hs/src/OpenCascade/BRepPrimAPI/MakeRevol.hs
+++ b/opencascade-hs/src/OpenCascade/BRepPrimAPI/MakeRevol.hs
@@ -10,11 +10,18 @@ import OpenCascade.BRepPrimAPI.Internal.Destructors (deleteMakeRevol)
 import qualified OpenCascade.TopoDS as TopoDS
 import qualified OpenCascade.GP as GP
 import OpenCascade.Internal.Bool (boolToCBool)
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.C
 import Foreign.Ptr
 import Data.Acquire
 
-foreign import capi unsafe "hs_BRepPrimAPI_MakeRevol.h hs_new_BRepPrimAPI_MakeRevol_fromShapeAndAx1" rawFromShapeAndAx1 :: Ptr TopoDS.Shape -> Ptr GP.Ax1 -> CBool -> IO (Ptr MakeRevol)
+foreign import capi unsafe "hs_BRepPrimAPI_MakeRevol.h hs_new_BRepPrimAPI_MakeRevol_fromShapeAndAx1" rawFromShapeAndAx1
+    :: Ptr TopoDS.Shape
+    -> Ptr GP.Ax1
+    -> CBool
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr MakeRevol)
 
 fromShapeAndAx1 :: Ptr TopoDS.Shape -> Ptr GP.Ax1 -> Bool -> Acquire (Ptr MakeRevol)
-fromShapeAndAx1 shape axis copy = mkAcquire (rawFromShapeAndAx1 shape axis (boolToCBool copy)) deleteMakeRevol
+fromShapeAndAx1 shape axis copy = mkAcquire (wrapException $ rawFromShapeAndAx1 shape axis (boolToCBool copy)) deleteMakeRevol

--- a/opencascade-hs/src/OpenCascade/BRepPrimAPI/MakeSphere.hs
+++ b/opencascade-hs/src/OpenCascade/BRepPrimAPI/MakeSphere.hs
@@ -7,17 +7,27 @@ module OpenCascade.BRepPrimAPI.MakeSphere
 import qualified OpenCascade.GP as GP
 import qualified OpenCascade.TopoDS as TopoDS
 import qualified OpenCascade.TopoDS.Internal.Destructors as TopoDS.Destructors
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.C
 import Foreign.Ptr
-import Data.Acquire 
+import Data.Acquire
 import Data.Coerce (coerce)
 
-foreign import capi unsafe "hs_BRepPrimAPI_MakeSphere.h hs_BRepPrimAPI_MakeSphere_fromRadius" rawFromRadius :: CDouble -> IO (Ptr TopoDS.Solid)
+foreign import capi unsafe "hs_BRepPrimAPI_MakeSphere.h hs_BRepPrimAPI_MakeSphere_fromRadius" rawFromRadius
+    :: CDouble
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Solid)
 
 fromRadius :: Double -> Acquire (Ptr TopoDS.Solid)
-fromRadius r = mkAcquire (rawFromRadius (coerce r)) (TopoDS.Destructors.deleteShape . castPtr)
+fromRadius r = mkAcquire (wrapException $ rawFromRadius (coerce r)) (TopoDS.Destructors.deleteShape . castPtr)
 
-foreign import capi unsafe "hs_BRepPrimAPI_MakeSphere.h hs_BRepPrimAPI_MakeSphere_fromPntAndRadius" rawFromPntAndRadius :: Ptr GP.Pnt -> CDouble -> IO (Ptr TopoDS.Solid)
+foreign import capi unsafe "hs_BRepPrimAPI_MakeSphere.h hs_BRepPrimAPI_MakeSphere_fromPntAndRadius" rawFromPntAndRadius
+    :: Ptr GP.Pnt
+    -> CDouble
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Solid)
 
 fromPntAndRadius :: Ptr GP.Pnt -> Double -> Acquire (Ptr TopoDS.Solid)
-fromPntAndRadius center radius = mkAcquire (rawFromPntAndRadius center (coerce radius)) (TopoDS.Destructors.deleteShape . castPtr)
+fromPntAndRadius center radius = mkAcquire (wrapException $ rawFromPntAndRadius center (coerce radius)) (TopoDS.Destructors.deleteShape . castPtr)

--- a/opencascade-hs/src/OpenCascade/BRepPrimAPI/MakeTorus.hs
+++ b/opencascade-hs/src/OpenCascade/BRepPrimAPI/MakeTorus.hs
@@ -5,6 +5,7 @@ module OpenCascade.BRepPrimAPI.MakeTorus
 
 import OpenCascade.BRepPrimAPI.Types (MakeTorus)
 import OpenCascade.BRepPrimAPI.Internal.Destructors (deleteMakeTorus)
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.C
 import Foreign.Ptr
 import Data.Acquire
@@ -12,7 +13,12 @@ import Data.Coerce (coerce)
 
 -- new
 
-foreign import capi unsafe "hs_BRepPrimAPI_MakeTorus.h hs_new_BRepPrimAPI_MakeTorus_fromRadii" rawFromRadii :: CDouble -> CDouble ->  IO (Ptr MakeTorus)
+foreign import capi unsafe "hs_BRepPrimAPI_MakeTorus.h hs_new_BRepPrimAPI_MakeTorus_fromRadii" rawFromRadii
+    :: CDouble
+    -> CDouble
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr MakeTorus)
 
 fromRadii :: Double -> Double -> Acquire (Ptr MakeTorus)
-fromRadii major minor = mkAcquire (rawFromRadii (coerce major) (coerce minor)) deleteMakeTorus
+fromRadii major minor = mkAcquire (wrapException $ rawFromRadii (coerce major) (coerce minor)) deleteMakeTorus

--- a/opencascade-hs/src/OpenCascade/BRepTools/WireExplorer.hs
+++ b/opencascade-hs/src/OpenCascade/BRepTools/WireExplorer.hs
@@ -12,23 +12,42 @@ import qualified OpenCascade.TopoDS as TopoDS
 import OpenCascade.BRepTools.Types (WireExplorer)
 import OpenCascade.BRepTools.Internal.Destructors (deleteWireExplorer)
 import OpenCascade.Internal.Bool (cBoolToBool)
+import OpenCascade.Internal.Exception (wrapException)
 import qualified OpenCascade.TopAbs as TopAbs
 import Foreign.Ptr
 import Foreign.C
 import Data.Acquire
-foreign import capi unsafe "hs_BRepTools_WireExplorer.h hs_new_BRepTools_WireExplorer_fromWire" rawNew :: Ptr TopoDS.Wire -> IO (Ptr WireExplorer)
+foreign import capi unsafe "hs_BRepTools_WireExplorer.h hs_new_BRepTools_WireExplorer_fromWire" rawNew
+    :: Ptr TopoDS.Wire
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr WireExplorer)
 
 fromWire :: Ptr TopoDS.Wire -> Acquire (Ptr WireExplorer)
-fromWire wire = mkAcquire (rawNew wire) deleteWireExplorer
+fromWire wire = mkAcquire (wrapException $ rawNew wire) deleteWireExplorer
 
 foreign import capi unsafe "hs_BRepTools_WireExplorer.h hs_BRepTools_WireExplorer_more" rawMore :: Ptr WireExplorer -> IO (CBool)
 
 more :: Ptr WireExplorer -> IO Bool
-more = fmap (cBoolToBool) . rawMore 
+more = fmap (cBoolToBool) . rawMore
 
-foreign import capi unsafe "hs_BRepTools_WireExplorer.h hs_BRepTools_WireExplorer_next" next :: Ptr WireExplorer -> IO ()
+foreign import capi unsafe "hs_BRepTools_WireExplorer.h hs_BRepTools_WireExplorer_next" rawNext
+    :: Ptr WireExplorer
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
 
-foreign import capi unsafe "hs_BRepTools_WireExplorer.h hs_BRepTools_WireExplorer_current" current :: Ptr WireExplorer -> IO (Ptr TopoDS.Edge)
+next :: Ptr WireExplorer -> IO ()
+next explorer = wrapException $ rawNext explorer
+
+foreign import capi unsafe "hs_BRepTools_WireExplorer.h hs_BRepTools_WireExplorer_current" rawCurrent
+    :: Ptr WireExplorer
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Edge)
+
+current :: Ptr WireExplorer -> IO (Ptr TopoDS.Edge)
+current explorer = wrapException $ rawCurrent explorer
 
 foreign import capi unsafe "hs_BRepTools_WireExplorer.h hs_BRepTools_WireExplorer_orientation" rawOrientation :: Ptr WireExplorer -> IO (CInt)
 

--- a/opencascade-hs/src/OpenCascade/Bnd/Box.hs
+++ b/opencascade-hs/src/OpenCascade/Bnd/Box.hs
@@ -10,7 +10,9 @@ import OpenCascade.Bnd.Types
 import OpenCascade.Bnd.Internal.Destructors (deleteBox)
 import OpenCascade.GP.Types (Pnt)
 import OpenCascade.GP.Internal.Destructors (deletePnt)
+import OpenCascade.Internal.Exception (wrapException)
 import Data.Acquire (Acquire, mkAcquire)
+import Foreign.C (CInt)
 import Foreign.Ptr (Ptr)
 
 foreign import capi unsafe "hs_Bnd_Box.h hs_new_Bnd_Box" rawNew ::  IO (Ptr Box)
@@ -18,12 +20,20 @@ foreign import capi unsafe "hs_Bnd_Box.h hs_new_Bnd_Box" rawNew ::  IO (Ptr Box)
 new :: Acquire (Ptr Box)
 new = mkAcquire rawNew deleteBox
 
-foreign import capi unsafe "hs_Bnd_Box.h hs_Bnd_Box_cornerMin" rawCornerMin :: Ptr Box -> IO (Ptr Pnt)
+foreign import capi unsafe "hs_Bnd_Box.h hs_Bnd_Box_cornerMin" rawCornerMin
+    :: Ptr Box
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr Pnt)
 
 cornerMin :: Ptr Box -> Acquire (Ptr Pnt)
-cornerMin box = mkAcquire (rawCornerMin box) deletePnt
+cornerMin box = mkAcquire (wrapException $ rawCornerMin box) deletePnt
 
-foreign import capi unsafe "hs_Bnd_Box.h hs_Bnd_Box_cornerMax" rawCornerMax :: Ptr Box -> IO (Ptr Pnt)
+foreign import capi unsafe "hs_Bnd_Box.h hs_Bnd_Box_cornerMax" rawCornerMax
+    :: Ptr Box
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr Pnt)
 
 cornerMax :: Ptr Box -> Acquire (Ptr Pnt)
-cornerMax box = mkAcquire (rawCornerMax box) deletePnt
+cornerMax box = mkAcquire (wrapException $ rawCornerMax box) deletePnt

--- a/opencascade-hs/src/OpenCascade/Font/BRepFont.hs
+++ b/opencascade-hs/src/OpenCascade/Font/BRepFont.hs
@@ -18,6 +18,7 @@ import Foreign.Ptr
 import OpenCascade.Font.Internal.Destructors (deleteBRepFont)
 import Data.Coerce
 import OpenCascade.Internal.Bool (cBoolToBool)
+import OpenCascade.Internal.Exception (wrapException)
 import OpenCascade.Font.FontAspect (FontAspect)
 
 
@@ -26,21 +27,39 @@ foreign import capi unsafe "hs_Font_BRepFont.h hs_new_Font_BRepFont" rawNew :: I
 new :: Acquire (Ptr BRepFont)
 new  = mkAcquire rawNew deleteBRepFont
 
-foreign import capi unsafe "hs_Font_BRepFont.h hs_new_Font_BRepFont_fromStringAndSize" rawFromPathAndSize :: CString -> CDouble -> IO (Ptr BRepFont)
+foreign import capi unsafe "hs_Font_BRepFont.h hs_new_Font_BRepFont_fromStringAndSize" rawFromPathAndSize
+    :: CString
+    -> CDouble
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr BRepFont)
 
 fromPathAndSize :: FilePath -> Double -> Acquire (Ptr BRepFont)
-fromPathAndSize path size = mkAcquire (withCString path $ \str -> rawFromPathAndSize str (coerce size)) deleteBRepFont
+fromPathAndSize path size = mkAcquire (withCString path $ \str -> wrapException $ rawFromPathAndSize str (coerce size)) deleteBRepFont
 
-foreign import capi unsafe "hs_Font_BRepFont.h hs_Font_BRepFont_initPathAndSize" rawInitFromPathAndSize :: Ptr BRepFont ->  CString -> CDouble -> IO CBool
+foreign import capi unsafe "hs_Font_BRepFont.h hs_Font_BRepFont_initPathAndSize" rawInitFromPathAndSize
+    :: Ptr BRepFont
+    -> CString
+    -> CDouble
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO CBool
 
 initFromPathAndSize :: Ptr BRepFont -> FilePath -> Double -> IO Bool
-initFromPathAndSize font fontPath size = withCString fontPath $ \str -> cBoolToBool <$> rawInitFromPathAndSize font str (coerce size)
+initFromPathAndSize font fontPath size = withCString fontPath $ \str -> cBoolToBool <$> wrapException (rawInitFromPathAndSize font str (coerce size))
 
-foreign import capi unsafe "hs_Font_BRepFont.h hs_Font_BRepFont_initNameAspectAndSize" rawInitFromNameAspectAndSize :: Ptr BRepFont ->  CString -> CInt -> CDouble -> IO CBool
+foreign import capi unsafe "hs_Font_BRepFont.h hs_Font_BRepFont_initNameAspectAndSize" rawInitFromNameAspectAndSize
+    :: Ptr BRepFont
+    -> CString
+    -> CInt
+    -> CDouble
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO CBool
 
 initFromNameAspectAndSize :: Ptr BRepFont -> String -> FontAspect -> Double -> IO Bool
-initFromNameAspectAndSize font fontname aspect size = 
-    withCString fontname $ \str -> cBoolToBool <$> rawInitFromNameAspectAndSize font str (fromIntegral . fromEnum $ aspect) (coerce size)
+initFromNameAspectAndSize font fontname aspect size =
+    withCString fontname $ \str -> cBoolToBool <$> wrapException (rawInitFromNameAspectAndSize font str (fromIntegral . fromEnum $ aspect) (coerce size))
 
 
 foreign import capi unsafe "hs_Font_BRepFont.h hs_Font_BRepFont_ascender" rawAscender :: Ptr BRepFont -> IO CDouble

--- a/opencascade-hs/src/OpenCascade/Font/BRepTextBuilder.hs
+++ b/opencascade-hs/src/OpenCascade/Font/BRepTextBuilder.hs
@@ -15,6 +15,7 @@ import qualified OpenCascade.Graphic3D.HorizontalTextAlignment as HTA
 import qualified OpenCascade.TopoDS as TopoDS
 import qualified OpenCascade.GP as GP
 import OpenCascade.TopoDS.Internal.Destructors (deleteShape)
+import OpenCascade.Internal.Exception (wrapException)
 
 foreign import capi unsafe "hs_Font_BRepTextBuilder.h hs_new_Font_BRepTextBuilder" rawNew :: IO (Ptr BRepTextBuilder)
 
@@ -22,10 +23,19 @@ new :: Acquire (Ptr BRepTextBuilder)
 new = mkAcquire rawNew deleteBRepTextBuilder
 
 
-foreign import capi unsafe "hs_Font_BRepTextBuilder.h hs_Font_BRepTextBuilder_perform" rawPerform :: Ptr BRepTextBuilder -> Ptr BRepFont -> CString -> Ptr GP.Ax3 -> CInt -> CInt -> IO (Ptr TopoDS.Shape)
+foreign import capi unsafe "hs_Font_BRepTextBuilder.h hs_Font_BRepTextBuilder_perform" rawPerform
+    :: Ptr BRepTextBuilder
+    -> Ptr BRepFont
+    -> CString
+    -> Ptr GP.Ax3
+    -> CInt
+    -> CInt
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Shape)
 
 perform :: Ptr BRepTextBuilder -> Ptr BRepFont -> String -> Ptr GP.Ax3 -> HTA.HorizontalTextAlignment -> VTA.VerticalTextAlignment -> Acquire (Ptr TopoDS.Shape)
 perform builder font str axis hAlign vAlign =
-     mkAcquire 
-        (withCString str $ \s -> rawPerform builder font s axis (fromIntegral . fromEnum $ hAlign) (fromIntegral . fromEnum $ vAlign)) 
+     mkAcquire
+        (withCString str $ \s -> wrapException $ rawPerform builder font s axis (fromIntegral . fromEnum $ hAlign) (fromIntegral . fromEnum $ vAlign))
         deleteShape

--- a/opencascade-hs/src/OpenCascade/GC/MakeArcOfCircle.hs
+++ b/opencascade-hs/src/OpenCascade/GC/MakeArcOfCircle.hs
@@ -8,24 +8,38 @@ import qualified OpenCascade.Geom.Internal.Destructors as Geom.Destructors
 import qualified OpenCascade.GP as GP
 import qualified OpenCascade.Geom as Geom
 import OpenCascade.Handle
+import OpenCascade.Internal.Exception (wrapException)
+import Foreign.C (CInt)
 import Foreign.Ptr
-import Data.Acquire 
+import Data.Acquire
 
 
 -- from3Pnts
 
-foreign import capi unsafe "hs_GC_MakeArcOfCircle.h hs_GC_MakeArcOfCircle_from3Pnts" rawFrom3Pnts :: Ptr GP.Pnt -> Ptr GP.Pnt -> Ptr GP.Pnt -> IO (Ptr (Handle (Geom.TrimmedCurve)))
+foreign import capi unsafe "hs_GC_MakeArcOfCircle.h hs_GC_MakeArcOfCircle_from3Pnts" rawFrom3Pnts
+    :: Ptr GP.Pnt
+    -> Ptr GP.Pnt
+    -> Ptr GP.Pnt
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr (Handle (Geom.TrimmedCurve)))
 
 from3Pnts :: Ptr GP.Pnt -> Ptr GP.Pnt -> Ptr GP.Pnt -> Acquire (Ptr (Handle Geom.TrimmedCurve))
-from3Pnts start mid end = mkAcquire (rawFrom3Pnts start mid end) Geom.Destructors.deleteHandleTrimmedCurve
+from3Pnts start mid end = mkAcquire (wrapException $ rawFrom3Pnts start mid end) Geom.Destructors.deleteHandleTrimmedCurve
 
 
 -- fromPntsAndVec
 
-foreign import capi unsafe "hs_GC_MakeArcOfCircle.h hs_GC_MakeArcOfCircle_fromPntsAndVec" rawFromPntsAndVec :: Ptr GP.Pnt -> Ptr GP.Vec -> Ptr GP.Pnt -> IO (Ptr (Handle (Geom.TrimmedCurve)))
+foreign import capi unsafe "hs_GC_MakeArcOfCircle.h hs_GC_MakeArcOfCircle_fromPntsAndVec" rawFromPntsAndVec
+    :: Ptr GP.Pnt
+    -> Ptr GP.Vec
+    -> Ptr GP.Pnt
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr (Handle (Geom.TrimmedCurve)))
 
 fromPntsAndVec :: Ptr GP.Pnt -> Ptr GP.Vec -> Ptr GP.Pnt -> Acquire (Ptr (Handle Geom.TrimmedCurve))
-fromPntsAndVec start dir end = mkAcquire (rawFromPntsAndVec start dir end) Geom.Destructors.deleteHandleTrimmedCurve
+fromPntsAndVec start dir end = mkAcquire (wrapException $ rawFromPntsAndVec start dir end) Geom.Destructors.deleteHandleTrimmedCurve
 
 
 

--- a/opencascade-hs/src/OpenCascade/GC/MakeSegment.hs
+++ b/opencascade-hs/src/OpenCascade/GC/MakeSegment.hs
@@ -7,13 +7,20 @@ import qualified OpenCascade.Geom.Internal.Destructors as Geom.Destructors
 import qualified OpenCascade.GP as GP
 import qualified OpenCascade.Geom as Geom
 import OpenCascade.Handle
+import OpenCascade.Internal.Exception (wrapException)
+import Foreign.C (CInt)
 import Foreign.Ptr
-import Data.Acquire 
+import Data.Acquire
 
 
 -- fromPnts
 
-foreign import capi unsafe "hs_GC_MakeSegment.h hs_GC_MakeSegment_fromPnts" rawFromPnts :: Ptr GP.Pnt -> Ptr GP.Pnt -> IO (Ptr (Handle (Geom.TrimmedCurve)))
+foreign import capi unsafe "hs_GC_MakeSegment.h hs_GC_MakeSegment_fromPnts" rawFromPnts
+    :: Ptr GP.Pnt
+    -> Ptr GP.Pnt
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr (Handle (Geom.TrimmedCurve)))
 
 fromPnts :: Ptr GP.Pnt -> Ptr GP.Pnt -> Acquire (Ptr (Handle Geom.TrimmedCurve))
-fromPnts start end = mkAcquire (rawFromPnts start end) Geom.Destructors.deleteHandleTrimmedCurve
+fromPnts start end = mkAcquire (wrapException $ rawFromPnts start end) Geom.Destructors.deleteHandleTrimmedCurve

--- a/opencascade-hs/src/OpenCascade/GCPnts/AbscissaPoint.hs
+++ b/opencascade-hs/src/OpenCascade/GCPnts/AbscissaPoint.hs
@@ -10,20 +10,31 @@ import OpenCascade.GCPnts.Types (AbscissaPoint)
 import OpenCascade.GCPnts.Internal.Destructors (deleteAbscissaPoint)
 import qualified OpenCascade.BRepAdaptor.Types as BRepAdaptor
 import OpenCascade.Internal.Bool (cBoolToBool)
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.Ptr
 import Foreign.C
 import Data.Acquire (Acquire, mkAcquire)
 import Data.Coerce (coerce)
 
-foreign import capi unsafe "hs_GCPnts_AbscissaPoint.h hs_new_GCPnts_AbscissaPoint" rawNew :: Ptr BRepAdaptor.Curve -> CDouble -> CDouble -> IO (Ptr AbscissaPoint)
+foreign import capi unsafe "hs_GCPnts_AbscissaPoint.h hs_new_GCPnts_AbscissaPoint" rawNew
+    :: Ptr BRepAdaptor.Curve
+    -> CDouble
+    -> CDouble
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr AbscissaPoint)
 
 fromCurveAbscissaAndParam :: Ptr BRepAdaptor.Curve -> Double -> Double -> Acquire (Ptr AbscissaPoint)
-fromCurveAbscissaAndParam curve abscissa u0 = mkAcquire (rawNew curve (CDouble abscissa) (CDouble u0)) deleteAbscissaPoint
+fromCurveAbscissaAndParam curve abscissa u0 = mkAcquire (wrapException $ rawNew curve (CDouble abscissa) (CDouble u0)) deleteAbscissaPoint
 
-foreign import capi unsafe "hs_GCPnts_AbscissaPoint.h hs_GCPnts_AbscissaPoint_parameter" rawParameter :: Ptr AbscissaPoint -> IO CDouble
+foreign import capi unsafe "hs_GCPnts_AbscissaPoint.h hs_GCPnts_AbscissaPoint_parameter" rawParameter
+    :: Ptr AbscissaPoint
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO CDouble
 
 parameter :: Ptr AbscissaPoint -> IO Double
-parameter = coerce rawParameter
+parameter p = coerce <$> wrapException (rawParameter p)
 
 foreign import capi unsafe "hs_GCPnts_AbscissaPoint.h hs_GCPnts_AbscissaPoint_isDone" rawIsDone :: Ptr AbscissaPoint -> IO CBool
 

--- a/opencascade-hs/src/OpenCascade/GP/Ax2.hs
+++ b/opencascade-hs/src/OpenCascade/GP/Ax2.hs
@@ -36,17 +36,18 @@ module OpenCascade.GP.Ax2
 import Prelude hiding (reverse)
 import OpenCascade.GP.Types
 import OpenCascade.GP.Internal.Destructors
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.Ptr
 import Foreign.C.Types
-import Data.Acquire 
+import Data.Acquire
 import Data.Coerce (coerce)
 
 -- new and delete
 
-foreign import capi unsafe "hs_gp_Ax2.h hs_new_gp_Ax2" rawNew :: Ptr Pnt -> Ptr Dir -> Ptr Dir -> IO (Ptr Ax2)
+foreign import capi unsafe "hs_gp_Ax2.h hs_new_gp_Ax2" rawNew :: Ptr Pnt -> Ptr Dir -> Ptr Dir -> Ptr CInt -> Ptr (Ptr ()) -> IO (Ptr Ax2)
 
 new :: Ptr Pnt -> Ptr Dir -> Ptr Dir -> Acquire (Ptr Ax2)
-new origin vAxis vX = mkAcquire (rawNew origin vAxis vX) deleteAx2
+new origin vAxis vX = mkAcquire (wrapException $ rawNew origin vAxis vX) deleteAx2
 
 foreign import capi unsafe "hs_gp_Ax2.h hs_new_gp_Ax2_autoX" rawNewAutoX :: Ptr Pnt -> Ptr Dir -> IO (Ptr Ax2)
 
@@ -83,15 +84,27 @@ axis ax2 = mkAcquire (rawAxis ax2) deleteAx1
 
 -- setters
 
-foreign import capi unsafe "hs_gp_Ax2.h hs_gp_Ax2_SetDirection" setDirection :: Ptr Ax2 -> Ptr Dir -> IO ()
+foreign import capi unsafe "hs_gp_Ax2.h hs_gp_Ax2_SetDirection" rawSetDirection :: Ptr Ax2 -> Ptr Dir -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
+
+setDirection :: Ptr Ax2 -> Ptr Dir -> IO ()
+setDirection ax2 dir = wrapException $ rawSetDirection ax2 dir
 
 foreign import capi unsafe "hs_gp_Ax2.h hs_gp_Ax2_SetLocation" setLocation :: Ptr Ax2 -> Ptr Pnt -> IO ()
 
-foreign import capi unsafe "hs_gp_Ax2.h hs_gp_Ax2_SetXDirection" setXDirection :: Ptr Ax2 -> Ptr Dir -> IO ()
+foreign import capi unsafe "hs_gp_Ax2.h hs_gp_Ax2_SetXDirection" rawSetXDirection :: Ptr Ax2 -> Ptr Dir -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
-foreign import capi unsafe "hs_gp_Ax2.h hs_gp_Ax2_SetYDirection" setYDirection :: Ptr Ax2 -> Ptr Dir -> IO ()
+setXDirection :: Ptr Ax2 -> Ptr Dir -> IO ()
+setXDirection ax2 dir = wrapException $ rawSetXDirection ax2 dir
 
-foreign import capi unsafe "hs_gp_Ax2.h hs_gp_Ax2_SetAxis" setAxis :: Ptr Ax2 -> Ptr Ax1 -> IO ()
+foreign import capi unsafe "hs_gp_Ax2.h hs_gp_Ax2_SetYDirection" rawSetYDirection :: Ptr Ax2 -> Ptr Dir -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
+
+setYDirection :: Ptr Ax2 -> Ptr Dir -> IO ()
+setYDirection ax2 dir = wrapException $ rawSetYDirection ax2 dir
+
+foreign import capi unsafe "hs_gp_Ax2.h hs_gp_Ax2_SetAxis" rawSetAxis :: Ptr Ax2 -> Ptr Ax1 -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
+
+setAxis :: Ptr Ax2 -> Ptr Ax1 -> IO ()
+setAxis ax2 ax1 = wrapException $ rawSetAxis ax2 ax1
 
 -- isCoplanar
 

--- a/opencascade-hs/src/OpenCascade/GP/Ax3.hs
+++ b/opencascade-hs/src/OpenCascade/GP/Ax3.hs
@@ -42,10 +42,11 @@ module OpenCascade.GP.Ax3
 
 import OpenCascade.GP.Types
 import OpenCascade.GP.Internal.Destructors
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.Ptr
 import Foreign.C.Types
 import OpenCascade.Internal.Bool (cBoolToBool)
-import Data.Acquire 
+import Data.Acquire
 import Data.Coerce (coerce)
 
 foreign import capi unsafe "hs_gp_Ax3.h hs_new_gp_Ax3" rawNew :: IO (Ptr Ax3)
@@ -58,10 +59,10 @@ foreign import capi unsafe "hs_gp_Ax3.h hs_new_gp_Ax3_fromAx2" rawFromAx2 :: Ptr
 fromAx2 :: Ptr Ax2 -> Acquire (Ptr Ax3)
 fromAx2 ax = mkAcquire (rawFromAx2 ax) deleteAx3
 
-foreign import capi unsafe "hs_gp_Ax3.h hs_new_gp_Ax3_fromPntDirAndDir" rawFromPntDirAndDir :: Ptr Pnt -> Ptr Dir -> Ptr Dir -> IO (Ptr Ax3)
+foreign import capi unsafe "hs_gp_Ax3.h hs_new_gp_Ax3_fromPntDirAndDir" rawFromPntDirAndDir :: Ptr Pnt -> Ptr Dir -> Ptr Dir -> Ptr CInt -> Ptr (Ptr ()) -> IO (Ptr Ax3)
 
 fromPntDirAndDir :: Ptr Pnt -> Ptr Dir -> Ptr Dir -> Acquire (Ptr Ax3)
-fromPntDirAndDir pnt u v = mkAcquire (rawFromPntDirAndDir pnt u v) deleteAx3 
+fromPntDirAndDir pnt u v = mkAcquire (wrapException $ rawFromPntDirAndDir pnt u v) deleteAx3
 
 foreign import capi unsafe "hs_gp_Ax3.h hs_new_gp_Ax3_fromPntAndDir" rawFromPntAndDir :: Ptr Pnt -> Ptr Dir -> IO (Ptr Ax3)
 
@@ -74,15 +75,27 @@ foreign import capi unsafe "hs_gp_Ax3.h hs_gp_Ax3_yReverse" yReverse :: Ptr Ax3 
 
 foreign import capi unsafe "hs_gp_Ax3.h hs_gp_Ax3_zReverse" zReverse :: Ptr Ax3 -> IO ()
 
-foreign import capi unsafe "hs_gp_Ax3.h hs_gp_Ax3_setAxis" setAxis :: Ptr Ax3 -> Ptr Ax1 -> IO ()
+foreign import capi unsafe "hs_gp_Ax3.h hs_gp_Ax3_setAxis" rawSetAxis :: Ptr Ax3 -> Ptr Ax1 -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
-foreign import capi unsafe "hs_gp_Ax3.h hs_gp_Ax3_setDirection" setDirection :: Ptr Ax3 -> Ptr Dir -> IO ()
+setAxis :: Ptr Ax3 -> Ptr Ax1 -> IO ()
+setAxis ax mainAxis = wrapException $ rawSetAxis ax mainAxis
+
+foreign import capi unsafe "hs_gp_Ax3.h hs_gp_Ax3_setDirection" rawSetDirection :: Ptr Ax3 -> Ptr Dir -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
+
+setDirection :: Ptr Ax3 -> Ptr Dir -> IO ()
+setDirection ax dir = wrapException $ rawSetDirection ax dir
 
 foreign import capi unsafe "hs_gp_Ax3.h hs_gp_Ax3_setLocation" setLocation :: Ptr Ax3 -> Ptr Pnt -> IO ()
 
-foreign import capi unsafe "hs_gp_Ax3.h hs_gp_Ax3_setXDirection" setXDirection :: Ptr Ax3 -> Ptr Dir -> IO ()
+foreign import capi unsafe "hs_gp_Ax3.h hs_gp_Ax3_setXDirection" rawSetXDirection :: Ptr Ax3 -> Ptr Dir -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
-foreign import capi unsafe "hs_gp_Ax3.h hs_gp_Ax3_setYDirection" setYDirection :: Ptr Ax3 -> Ptr Dir -> IO ()
+setXDirection :: Ptr Ax3 -> Ptr Dir -> IO ()
+setXDirection ax dir = wrapException $ rawSetXDirection ax dir
+
+foreign import capi unsafe "hs_gp_Ax3.h hs_gp_Ax3_setYDirection" rawSetYDirection :: Ptr Ax3 -> Ptr Dir -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
+
+setYDirection :: Ptr Ax3 -> Ptr Dir -> IO ()
+setYDirection ax dir = wrapException $ rawSetYDirection ax dir
 
 foreign import capi unsafe "hs_gp_Ax3.h hs_gp_Ax3_angle" rawAngle :: Ptr Ax3 -> Ptr Ax3 -> IO CDouble 
 

--- a/opencascade-hs/src/OpenCascade/GP/Dir.hs
+++ b/opencascade-hs/src/OpenCascade/GP/Dir.hs
@@ -38,17 +38,18 @@ module OpenCascade.GP.Dir
 import Prelude hiding (reverse)
 import OpenCascade.GP.Types
 import OpenCascade.GP.Internal.Destructors
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.C
 import Foreign.Ptr
 import Data.Coerce (coerce)
-import Data.Acquire 
+import Data.Acquire
 
 -- new
 
-foreign import capi unsafe "hs_gp_Dir.h hs_new_gp_Dir" rawNew :: CDouble -> CDouble -> CDouble -> IO (Ptr Dir)
+foreign import capi unsafe "hs_gp_Dir.h hs_new_gp_Dir" rawNew :: CDouble -> CDouble -> CDouble -> Ptr CInt -> Ptr (Ptr ()) -> IO (Ptr Dir)
 
 new :: Double -> Double -> Double -> Acquire (Ptr Dir)
-new x y z = mkAcquire (rawNew (CDouble x) (CDouble y) (CDouble z)) deleteDir
+new x y z = mkAcquire (wrapException $ rawNew (CDouble x) (CDouble y) (CDouble z)) deleteDir
 
 -- getters
 
@@ -126,29 +127,35 @@ angle = coerce rawAngle
 
 -- angleWithRef
 
-foreign import capi unsafe "hs_gp_Dir.h hs_gp_Dir_AngleWithRef" rawAngleWithRef :: Ptr Dir -> Ptr Dir -> Ptr Dir -> IO CDouble
+foreign import capi unsafe "hs_gp_Dir.h hs_gp_Dir_AngleWithRef" rawAngleWithRef :: Ptr Dir -> Ptr Dir -> Ptr Dir -> Ptr CInt -> Ptr (Ptr ()) -> IO CDouble
 
 angleWithRef :: Ptr Dir -> Ptr Dir -> Ptr Dir -> IO Double
-angleWithRef = coerce rawAngleWithRef
+angleWithRef a b vref = coerce <$> wrapException (rawAngleWithRef a b vref)
 
 -- cross/crossed
 
-foreign import capi unsafe "hs_gp_Dir.h hs_gp_Dir_Cross" cross :: Ptr Dir -> Ptr Dir -> IO ()
+foreign import capi unsafe "hs_gp_Dir.h hs_gp_Dir_Cross" rawCross :: Ptr Dir -> Ptr Dir -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
-foreign import capi unsafe "hs_gp_Dir.h hs_gp_Dir_Crossed" rawCrossed :: Ptr Dir -> Ptr Dir -> IO (Ptr Dir)
+cross :: Ptr Dir -> Ptr Dir -> IO ()
+cross a b = wrapException $ rawCross a b
+
+foreign import capi unsafe "hs_gp_Dir.h hs_gp_Dir_Crossed" rawCrossed :: Ptr Dir -> Ptr Dir -> Ptr CInt -> Ptr (Ptr ()) -> IO (Ptr Dir)
 
 crossed :: Ptr Dir -> Ptr Dir -> Acquire (Ptr Dir)
-crossed a b = mkAcquire (rawCrossed a b) deleteDir
+crossed a b = mkAcquire (wrapException $ rawCrossed a b) deleteDir
 
 
 -- crossCross/crossCrossed
 
-foreign import capi unsafe "hs_gp_Dir.h hs_gp_Dir_CrossCross" crossCross :: Ptr Dir -> Ptr Dir -> Ptr Dir -> IO ()
+foreign import capi unsafe "hs_gp_Dir.h hs_gp_Dir_CrossCross" rawCrossCross :: Ptr Dir -> Ptr Dir -> Ptr Dir -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
-foreign import capi unsafe "hs_gp_Dir.h hs_gp_Dir_CrossCrossed" rawCrossCrossed :: Ptr Dir -> Ptr Dir -> Ptr Dir -> IO (Ptr Dir)
+crossCross :: Ptr Dir -> Ptr Dir -> Ptr Dir -> IO ()
+crossCross a b c = wrapException $ rawCrossCross a b c
+
+foreign import capi unsafe "hs_gp_Dir.h hs_gp_Dir_CrossCrossed" rawCrossCrossed :: Ptr Dir -> Ptr Dir -> Ptr Dir -> Ptr CInt -> Ptr (Ptr ()) -> IO (Ptr Dir)
 
 crossCrossed :: Ptr Dir -> Ptr Dir -> Ptr Dir -> Acquire (Ptr Dir)
-crossCrossed a b c = mkAcquire (rawCrossCrossed a b c) deleteDir
+crossCrossed a b c = mkAcquire (wrapException $ rawCrossCrossed a b c) deleteDir
 
 
 -- dot

--- a/opencascade-hs/src/OpenCascade/GP/Dir2d.hs
+++ b/opencascade-hs/src/OpenCascade/GP/Dir2d.hs
@@ -29,17 +29,18 @@ module OpenCascade.GP.Dir2d
 import Prelude hiding (reverse)
 import OpenCascade.GP.Types
 import OpenCascade.GP.Internal.Destructors
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.C
 import Foreign.Ptr
 import Data.Coerce (coerce)
-import Data.Acquire 
+import Data.Acquire
 
 -- new
 
-foreign import capi unsafe "hs_gp_Dir2d.h hs_new_gp_Dir2d" rawNew :: CDouble -> CDouble -> IO (Ptr Dir2d)
+foreign import capi unsafe "hs_gp_Dir2d.h hs_new_gp_Dir2d" rawNew :: CDouble -> CDouble -> Ptr CInt -> Ptr (Ptr ()) -> IO (Ptr Dir2d)
 
 new :: Double -> Double -> Acquire (Ptr Dir2d)
-new x y = mkAcquire (rawNew (CDouble x) (CDouble y)) deleteDir2d
+new x y = mkAcquire (wrapException $ rawNew (CDouble x) (CDouble y)) deleteDir2d
 
 -- getters
 

--- a/opencascade-hs/src/OpenCascade/GP/GTrsf.hs
+++ b/opencascade-hs/src/OpenCascade/GP/GTrsf.hs
@@ -8,19 +8,23 @@ module OpenCascade.GP.GTrsf
 
 import OpenCascade.GP.Types
 import OpenCascade.GP.Internal.Destructors
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.C
 import Foreign.Ptr
 import Data.Coerce (coerce)
-import Data.Acquire 
+import Data.Acquire
 
 foreign import capi unsafe "hs_gp_GTrsf.h hs_new_gp_GTrsf" rawNew ::IO (Ptr GTrsf)
 
 new :: Acquire (Ptr GTrsf)
 new = mkAcquire rawNew deleteGTrsf
 
-foreign import capi unsafe "hs_gp_GTrsf.h hs_gp_GTrsf_setValue" rawSetValue :: Ptr GTrsf -> CInt -> CInt -> CDouble -> IO () 
+foreign import capi unsafe "hs_gp_GTrsf.h hs_gp_GTrsf_setValue" rawSetValue :: Ptr GTrsf -> CInt -> CInt -> CDouble -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
 setValue :: Ptr GTrsf -> Int -> Int -> Double -> IO ()
-setValue trsf row column value = rawSetValue trsf (fromIntegral row) (fromIntegral column) (coerce value)
+setValue trsf row column value = wrapException $ rawSetValue trsf (fromIntegral row) (fromIntegral column) (coerce value)
 
-foreign import capi unsafe "hs_gp_GTrsf.h hs_gp_GTrsf_setForm" setForm :: Ptr GTrsf -> IO () 
+foreign import capi unsafe "hs_gp_GTrsf.h hs_gp_GTrsf_setForm" rawSetForm :: Ptr GTrsf -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
+
+setForm :: Ptr GTrsf -> IO ()
+setForm trsf = wrapException $ rawSetForm trsf

--- a/opencascade-hs/src/OpenCascade/GP/Trsf.hs
+++ b/opencascade-hs/src/OpenCascade/GP/Trsf.hs
@@ -27,10 +27,11 @@ module OpenCascade.GP.Trsf
 
 import OpenCascade.GP.Types
 import OpenCascade.GP.Internal.Destructors
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.C
 import Foreign.Ptr
 import Data.Coerce (coerce)
-import Data.Acquire 
+import Data.Acquire
 
 
 -- new
@@ -62,10 +63,10 @@ setRotationAboutAxisAngle = coerce rawSetRotationAboutAxisAngle
 
 -- scale
 
-foreign import capi unsafe "hs_gp_Trsf.h hs_gp_Trsf_SetScale" rawSetScale :: Ptr Trsf -> Ptr Pnt -> CDouble -> IO ()
+foreign import capi unsafe "hs_gp_Trsf.h hs_gp_Trsf_SetScale" rawSetScale :: Ptr Trsf -> Ptr Pnt -> CDouble -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
 setScale :: Ptr Trsf -> Ptr Pnt -> Double -> IO ()
-setScale = coerce rawSetScale
+setScale trsf origin factor = wrapException $ rawSetScale trsf origin (coerce factor)
 
 -- translation
 
@@ -79,17 +80,21 @@ foreign import capi unsafe "hs_gp_Trsf.h hs_gp_Trsf_SetDisplacement" setDisplace
 
 -- scaleFactor
 
-foreign import capi unsafe "hs_gp_Trsf.h hs_gp_Trsf_SetScaleFactor" rawSetScaleFactor :: Ptr Trsf -> CDouble -> IO ()
+foreign import capi unsafe "hs_gp_Trsf.h hs_gp_Trsf_SetScaleFactor" rawSetScaleFactor :: Ptr Trsf -> CDouble -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
 setScaleFactor :: Ptr Trsf -> Double -> IO ()
-setScaleFactor = coerce rawSetScaleFactor
+setScaleFactor trsf s = wrapException $ rawSetScaleFactor trsf (coerce s)
 
 -- setValues
 
-foreign import capi unsafe "hs_gp_Trsf.h hs_gp_Trsf_SetValues" rawSetValues :: Ptr Trsf -> CDouble -> CDouble-> CDouble-> CDouble-> CDouble-> CDouble-> CDouble-> CDouble-> CDouble-> CDouble-> CDouble-> CDouble -> IO ()
+foreign import capi unsafe "hs_gp_Trsf.h hs_gp_Trsf_SetValues" rawSetValues :: Ptr Trsf -> CDouble -> CDouble-> CDouble-> CDouble-> CDouble-> CDouble-> CDouble-> CDouble-> CDouble-> CDouble-> CDouble-> CDouble -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
 setValues :: Ptr Trsf -> Double -> Double-> Double-> Double-> Double-> Double-> Double-> Double-> Double-> Double-> Double-> Double -> IO ()
-setValues = coerce rawSetValues
+setValues trsf a11 a12 a13 a14 a21 a22 a23 a24 a31 a32 a33 a34 =
+    wrapException $ rawSetValues trsf
+        (coerce a11) (coerce a12) (coerce a13) (coerce a14)
+        (coerce a21) (coerce a22) (coerce a23) (coerce a24)
+        (coerce a31) (coerce a32) (coerce a33) (coerce a34)
 
 -- tests 
 
@@ -103,19 +108,22 @@ foreign import capi unsafe "hs_gp_Trsf.h hs_gp_Trsf_ScaleFactor" rawScaleFactor 
 scaleFactor :: Ptr Trsf -> IO Double
 scaleFactor = coerce rawScaleFactor
 
-foreign import capi unsafe "hs_gp_Trsf.h hs_gp_Trsf_Value" rawValue :: Ptr Trsf -> CInt -> CInt -> IO CDouble
+foreign import capi unsafe "hs_gp_Trsf.h hs_gp_Trsf_Value" rawValue :: Ptr Trsf -> CInt -> CInt -> Ptr CInt -> Ptr (Ptr ()) -> IO CDouble
 
 value :: Ptr Trsf -> Int -> Int -> IO Double
-value t row col = coerce $ rawValue t (fromIntegral row) (fromIntegral col)
+value t row col = coerce <$> wrapException (rawValue t (fromIntegral row) (fromIntegral col))
 
 -- invert/inverted
 
-foreign import capi unsafe "hs_gp_Trsf.h hs_gp_Trsf_Invert" invert :: Ptr Trsf-> IO ()
+foreign import capi unsafe "hs_gp_Trsf.h hs_gp_Trsf_Invert" rawInvert :: Ptr Trsf -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
-foreign import capi unsafe "hs_gp_Trsf.h hs_gp_Trsf_Inverted" rawInverted :: Ptr Trsf-> IO (Ptr Trsf)
+invert :: Ptr Trsf -> IO ()
+invert t = wrapException $ rawInvert t
+
+foreign import capi unsafe "hs_gp_Trsf.h hs_gp_Trsf_Inverted" rawInverted :: Ptr Trsf -> Ptr CInt -> Ptr (Ptr ()) -> IO (Ptr Trsf)
 
 inverted :: Ptr Trsf -> Acquire (Ptr Trsf)
-inverted t = mkAcquire (rawInverted t) deleteTrsf
+inverted t = mkAcquire (wrapException $ rawInverted t) deleteTrsf
 
 -- multiply/multiplied
 
@@ -132,12 +140,12 @@ foreign import capi unsafe "hs_gp_Trsf.h hs_gp_Trsf_PreMultiply" preMultiply :: 
 
 -- power/powered
 
-foreign import capi unsafe "hs_gp_Trsf.h hs_gp_Trsf_Power" rawPower :: Ptr Trsf -> CInt -> IO ()
+foreign import capi unsafe "hs_gp_Trsf.h hs_gp_Trsf_Power" rawPower :: Ptr Trsf -> CInt -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
 power :: Ptr Trsf -> Int -> IO ()
-power trsf times = rawPower trsf (fromIntegral times)
+power trsf times = wrapException $ rawPower trsf (fromIntegral times)
 
-foreign import capi unsafe "hs_gp_Trsf.h hs_gp_Trsf_Powered" rawPowered :: Ptr Trsf -> CInt -> IO (Ptr Trsf)
+foreign import capi unsafe "hs_gp_Trsf.h hs_gp_Trsf_Powered" rawPowered :: Ptr Trsf -> CInt -> Ptr CInt -> Ptr (Ptr ()) -> IO (Ptr Trsf)
 
 powered :: Ptr Trsf -> Int -> Acquire (Ptr Trsf)
-powered trsf times = mkAcquire (rawPowered trsf (fromIntegral times)) deleteTrsf
+powered trsf times = mkAcquire (wrapException $ rawPowered trsf (fromIntegral times)) deleteTrsf

--- a/opencascade-hs/src/OpenCascade/GP/Trsf2d.hs
+++ b/opencascade-hs/src/OpenCascade/GP/Trsf2d.hs
@@ -28,10 +28,11 @@ module OpenCascade.GP.Trsf2d
 
 import OpenCascade.GP.Types
 import OpenCascade.GP.Internal.Destructors
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.C
 import Foreign.Ptr
 import Data.Coerce (coerce)
-import Data.Acquire 
+import Data.Acquire
 
 
 -- new
@@ -61,10 +62,10 @@ setRotation = coerce rawSetRotation
 
 -- scale
 
-foreign import capi unsafe "hs_gp_Trsf2d.h hs_gp_Trsf2d_SetScale" rawSetScale :: Ptr Trsf2d -> Ptr Pnt2d -> CDouble -> IO ()
+foreign import capi unsafe "hs_gp_Trsf2d.h hs_gp_Trsf2d_SetScale" rawSetScale :: Ptr Trsf2d -> Ptr Pnt2d -> CDouble -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
 setScale :: Ptr Trsf2d -> Ptr Pnt2d -> Double -> IO ()
-setScale = coerce rawSetScale
+setScale trsf origin factor = wrapException $ rawSetScale trsf origin (coerce factor)
 
 -- transformation
 
@@ -82,17 +83,20 @@ foreign import capi unsafe "hs_gp_Trsf2d.h hs_gp_Trsf2d_SetTranslationRelative" 
 
 -- scaleFactor
 
-foreign import capi unsafe "hs_gp_Trsf2d.h hs_gp_Trsf2d_SetScaleFactor" rawSetScaleFactor :: Ptr Trsf2d -> CDouble -> IO ()
+foreign import capi unsafe "hs_gp_Trsf2d.h hs_gp_Trsf2d_SetScaleFactor" rawSetScaleFactor :: Ptr Trsf2d -> CDouble -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
 setScaleFactor :: Ptr Trsf2d -> Double -> IO ()
-setScaleFactor = coerce rawSetScaleFactor
+setScaleFactor trsf s = wrapException $ rawSetScaleFactor trsf (coerce s)
 
 -- setValues
 
-foreign import capi unsafe "hs_gp_Trsf2d.h hs_gp_Trsf2d_SetValues" rawSetValues :: Ptr Trsf2d -> CDouble -> CDouble-> CDouble-> CDouble-> CDouble-> CDouble-> IO ()
+foreign import capi unsafe "hs_gp_Trsf2d.h hs_gp_Trsf2d_SetValues" rawSetValues :: Ptr Trsf2d -> CDouble -> CDouble-> CDouble-> CDouble-> CDouble-> CDouble-> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
 setValues :: Ptr Trsf2d -> Double -> Double -> Double -> Double-> Double -> Double -> IO ()
-setValues = coerce rawSetValues
+setValues trsf a11 a12 a13 a21 a22 a23 =
+    wrapException $ rawSetValues trsf
+        (coerce a11) (coerce a12) (coerce a13)
+        (coerce a21) (coerce a22) (coerce a23)
 
 -- tests 
 
@@ -106,19 +110,22 @@ foreign import capi unsafe "hs_gp_Trsf2d.h hs_gp_Trsf2d_ScaleFactor" rawScaleFac
 scaleFactor :: Ptr Trsf2d -> IO Double
 scaleFactor = coerce rawScaleFactor
 
-foreign import capi unsafe "hs_gp_Trsf2d.h hs_gp_Trsf2d_Value" rawValue :: Ptr Trsf2d -> CInt -> CInt -> IO CDouble
+foreign import capi unsafe "hs_gp_Trsf2d.h hs_gp_Trsf2d_Value" rawValue :: Ptr Trsf2d -> CInt -> CInt -> Ptr CInt -> Ptr (Ptr ()) -> IO CDouble
 
 value :: Ptr Trsf2d -> Int -> Int -> IO Double
-value t row col = coerce $ rawValue t (fromIntegral row) (fromIntegral col)
+value t row col = coerce <$> wrapException (rawValue t (fromIntegral row) (fromIntegral col))
 
 -- invert/inverted
 
-foreign import capi unsafe "hs_gp_Trsf2d.h hs_gp_Trsf2d_Invert" invert :: Ptr Trsf2d-> IO ()
+foreign import capi unsafe "hs_gp_Trsf2d.h hs_gp_Trsf2d_Invert" rawInvert :: Ptr Trsf2d -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
-foreign import capi unsafe "hs_gp_Trsf2d.h hs_gp_Trsf2d_Inverted" rawInverted :: Ptr Trsf2d-> IO (Ptr Trsf2d)
+invert :: Ptr Trsf2d -> IO ()
+invert t = wrapException $ rawInvert t
+
+foreign import capi unsafe "hs_gp_Trsf2d.h hs_gp_Trsf2d_Inverted" rawInverted :: Ptr Trsf2d -> Ptr CInt -> Ptr (Ptr ()) -> IO (Ptr Trsf2d)
 
 inverted :: Ptr Trsf2d -> Acquire (Ptr Trsf2d)
-inverted t = mkAcquire (rawInverted t) deleteTrsf2d
+inverted t = mkAcquire (wrapException $ rawInverted t) deleteTrsf2d
 
 -- multiply/multiplied
 
@@ -135,12 +142,12 @@ foreign import capi unsafe "hs_gp_Trsf2d.h hs_gp_Trsf2d_PreMultiply" preMultiply
 
 -- power/powered
 
-foreign import capi unsafe "hs_gp_Trsf2d.h hs_gp_Trsf2d_Power" rawPower :: Ptr Trsf2d -> CInt -> IO ()
+foreign import capi unsafe "hs_gp_Trsf2d.h hs_gp_Trsf2d_Power" rawPower :: Ptr Trsf2d -> CInt -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
 power :: Ptr Trsf2d -> Int -> IO ()
-power trsf times = rawPower trsf (fromIntegral times)
+power trsf times = wrapException $ rawPower trsf (fromIntegral times)
 
-foreign import capi unsafe "hs_gp_Trsf2d.h hs_gp_Trsf2d_Powered" rawPowered :: Ptr Trsf2d -> CInt -> IO (Ptr Trsf2d)
+foreign import capi unsafe "hs_gp_Trsf2d.h hs_gp_Trsf2d_Powered" rawPowered :: Ptr Trsf2d -> CInt -> Ptr CInt -> Ptr (Ptr ()) -> IO (Ptr Trsf2d)
 
 powered :: Ptr Trsf2d -> Int -> Acquire (Ptr Trsf2d)
-powered trsf times = mkAcquire (rawPowered trsf (fromIntegral times)) deleteTrsf2d
+powered trsf times = mkAcquire (wrapException $ rawPowered trsf (fromIntegral times)) deleteTrsf2d

--- a/opencascade-hs/src/OpenCascade/GP/Vec.hs
+++ b/opencascade-hs/src/OpenCascade/GP/Vec.hs
@@ -32,6 +32,8 @@ module OpenCascade.GP.Vec
 , crossSquareMagnitude
 , dot
 , dotCross
+, normalize
+, normalized
 , reverse
 , reversed
 , mirror
@@ -251,6 +253,19 @@ foreign import capi unsafe "hs_gp_Vec.h hs_gp_Vec_DotCross" rawDotCross :: Ptr V
 
 dotCross :: Ptr Vec -> Ptr Vec -> Ptr Vec -> IO Double
 dotCross = coerce rawDotCross
+
+
+-- normalize/normalized
+
+foreign import capi unsafe "hs_gp_Vec.h hs_gp_Vec_Normalize" rawNormalize :: Ptr Vec -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
+
+normalize :: Ptr Vec -> IO ()
+normalize a = wrapException $ rawNormalize a
+
+foreign import capi unsafe "hs_gp_Vec.h hs_gp_Vec_Normalized" rawNormalized :: Ptr Vec -> Ptr CInt -> Ptr (Ptr ()) -> IO (Ptr Vec)
+
+normalized :: Ptr Vec -> Acquire (Ptr Vec)
+normalized a = mkAcquire (wrapException $ rawNormalized a) deleteVec
 
 
 -- reverse/reversed

--- a/opencascade-hs/src/OpenCascade/GP/Vec.hs
+++ b/opencascade-hs/src/OpenCascade/GP/Vec.hs
@@ -52,10 +52,11 @@ module OpenCascade.GP.Vec
 import Prelude hiding (reverse, subtract)
 import OpenCascade.GP.Types
 import OpenCascade.GP.Internal.Destructors
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.C
 import Foreign.Ptr
 import Data.Coerce (coerce)
-import Data.Acquire 
+import Data.Acquire
 
 -- new
 
@@ -111,38 +112,38 @@ isEqual a b linearTolerance angularTolerance = (/= 0) <$> rawIsEqual a b (CDoubl
 
 -- isNormal
 
-foreign import capi unsafe "hs_gp_Vec.h hs_gp_Vec_IsNormal" rawIsNormal :: Ptr Vec -> Ptr Vec -> CDouble -> IO CBool
+foreign import capi unsafe "hs_gp_Vec.h hs_gp_Vec_IsNormal" rawIsNormal :: Ptr Vec -> Ptr Vec -> CDouble -> Ptr CInt -> Ptr (Ptr ()) -> IO CBool
 
 isNormal :: Ptr Vec -> Ptr Vec -> Double -> IO Bool
-isNormal a b tolerance = (/= 0) <$> rawIsNormal a b (CDouble tolerance)
+isNormal a b tolerance = (/= 0) <$> wrapException (rawIsNormal a b (CDouble tolerance))
 
 -- isOpposite
 
-foreign import capi unsafe "hs_gp_Vec.h hs_gp_Vec_IsOpposite" rawIsOpposite :: Ptr Vec -> Ptr Vec -> CDouble -> IO CBool
+foreign import capi unsafe "hs_gp_Vec.h hs_gp_Vec_IsOpposite" rawIsOpposite :: Ptr Vec -> Ptr Vec -> CDouble -> Ptr CInt -> Ptr (Ptr ()) -> IO CBool
 
 isOpposite :: Ptr Vec -> Ptr Vec -> Double -> IO Bool
-isOpposite a b tolerance = (/= 0) <$> rawIsOpposite a b (CDouble tolerance)
+isOpposite a b tolerance = (/= 0) <$> wrapException (rawIsOpposite a b (CDouble tolerance))
 
 -- isParallel
 
-foreign import capi unsafe "hs_gp_Vec.h hs_gp_Vec_IsParallel" rawIsParallel :: Ptr Vec -> Ptr Vec -> CDouble -> IO CBool
+foreign import capi unsafe "hs_gp_Vec.h hs_gp_Vec_IsParallel" rawIsParallel :: Ptr Vec -> Ptr Vec -> CDouble -> Ptr CInt -> Ptr (Ptr ()) -> IO CBool
 
 isParallel :: Ptr Vec -> Ptr Vec -> Double -> IO Bool
-isParallel a b tolerance = (/= 0) <$> rawIsParallel a b (CDouble tolerance)
+isParallel a b tolerance = (/= 0) <$> wrapException (rawIsParallel a b (CDouble tolerance))
 
 -- angle
 
-foreign import capi unsafe "hs_gp_Vec.h hs_gp_Vec_Angle" rawAngle :: Ptr Vec -> Ptr Vec -> IO CDouble
+foreign import capi unsafe "hs_gp_Vec.h hs_gp_Vec_Angle" rawAngle :: Ptr Vec -> Ptr Vec -> Ptr CInt -> Ptr (Ptr ()) -> IO CDouble
 
 angle :: Ptr Vec -> Ptr Vec -> IO Double
-angle = coerce rawAngle
+angle a b = coerce <$> wrapException (rawAngle a b)
 
 -- angleWithRef
 
-foreign import capi unsafe "hs_gp_Vec.h hs_gp_Vec_AngleWithRef" rawAngleWithRef :: Ptr Vec -> Ptr Vec -> Ptr Vec -> IO CDouble
+foreign import capi unsafe "hs_gp_Vec.h hs_gp_Vec_AngleWithRef" rawAngleWithRef :: Ptr Vec -> Ptr Vec -> Ptr Vec -> Ptr CInt -> Ptr (Ptr ()) -> IO CDouble
 
 angleWithRef :: Ptr Vec -> Ptr Vec -> Ptr Vec -> IO Double
-angleWithRef = coerce rawAngleWithRef
+angleWithRef a b vref = coerce <$> wrapException (rawAngleWithRef a b vref)
 
 
 -- magnitude

--- a/opencascade-hs/src/OpenCascade/GP/Vec2d.hs
+++ b/opencascade-hs/src/OpenCascade/GP/Vec2d.hs
@@ -25,6 +25,8 @@ module OpenCascade.GP.Vec2d
 , crossMagnitude
 , crossSquareMagnitude
 , dot
+, normalize
+, normalized
 , reverse
 , reversed
 , mirror
@@ -205,6 +207,18 @@ foreign import capi unsafe "hs_gp_Vec2d.h hs_gp_Vec2d_Dot" rawDot :: Ptr Vec2d -
 
 dot :: Ptr Vec2d -> Ptr Vec2d -> IO Double
 dot = coerce rawDot
+
+-- normalize/normalized
+
+foreign import capi unsafe "hs_gp_Vec2d.h hs_gp_Vec2d_Normalize" rawNormalize :: Ptr Vec2d -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
+
+normalize :: Ptr Vec2d -> IO ()
+normalize a = wrapException $ rawNormalize a
+
+foreign import capi unsafe "hs_gp_Vec2d.h hs_gp_Vec2d_Normalized" rawNormalized :: Ptr Vec2d -> Ptr CInt -> Ptr (Ptr ()) -> IO (Ptr Vec2d)
+
+normalized :: Ptr Vec2d -> Acquire (Ptr Vec2d)
+normalized a = mkAcquire (wrapException $ rawNormalized a) deleteVec2d
 
 -- reverse/reversed
 

--- a/opencascade-hs/src/OpenCascade/GP/Vec2d.hs
+++ b/opencascade-hs/src/OpenCascade/GP/Vec2d.hs
@@ -43,10 +43,11 @@ module OpenCascade.GP.Vec2d
 import Prelude hiding (reverse, subtract)
 import OpenCascade.GP.Types
 import OpenCascade.GP.Internal.Destructors
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.C
 import Foreign.Ptr
 import Data.Coerce (coerce)
-import Data.Acquire 
+import Data.Acquire
 
 -- new
 
@@ -91,31 +92,31 @@ isEqual a b linearTolerance angularTolerance = (/= 0) <$> rawIsEqual a b (CDoubl
 
 -- isNormal
 
-foreign import capi unsafe "hs_gp_Vec2d.h hs_gp_Vec2d_IsNormal" rawIsNormal :: Ptr Vec2d -> Ptr Vec2d -> CDouble -> IO CBool
+foreign import capi unsafe "hs_gp_Vec2d.h hs_gp_Vec2d_IsNormal" rawIsNormal :: Ptr Vec2d -> Ptr Vec2d -> CDouble -> Ptr CInt -> Ptr (Ptr ()) -> IO CBool
 
 isNormal :: Ptr Vec2d -> Ptr Vec2d -> Double -> IO Bool
-isNormal a b tolerance = (/= 0) <$> rawIsNormal a b (CDouble tolerance)
+isNormal a b tolerance = (/= 0) <$> wrapException (rawIsNormal a b (CDouble tolerance))
 
 -- isOpposite
 
-foreign import capi unsafe "hs_gp_Vec2d.h hs_gp_Vec2d_IsOpposite" rawIsOpposite :: Ptr Vec2d -> Ptr Vec2d -> CDouble -> IO CBool
+foreign import capi unsafe "hs_gp_Vec2d.h hs_gp_Vec2d_IsOpposite" rawIsOpposite :: Ptr Vec2d -> Ptr Vec2d -> CDouble -> Ptr CInt -> Ptr (Ptr ()) -> IO CBool
 
 isOpposite :: Ptr Vec2d -> Ptr Vec2d -> Double -> IO Bool
-isOpposite a b tolerance = (/= 0) <$> rawIsOpposite a b (CDouble tolerance)
+isOpposite a b tolerance = (/= 0) <$> wrapException (rawIsOpposite a b (CDouble tolerance))
 
 -- isParallel
 
-foreign import capi unsafe "hs_gp_Vec2d.h hs_gp_Vec2d_IsParallel" rawIsParallel :: Ptr Vec2d -> Ptr Vec2d -> CDouble -> IO CBool
+foreign import capi unsafe "hs_gp_Vec2d.h hs_gp_Vec2d_IsParallel" rawIsParallel :: Ptr Vec2d -> Ptr Vec2d -> CDouble -> Ptr CInt -> Ptr (Ptr ()) -> IO CBool
 
 isParallel :: Ptr Vec2d -> Ptr Vec2d -> Double -> IO Bool
-isParallel a b tolerance = (/= 0) <$> rawIsParallel a b (CDouble tolerance)
+isParallel a b tolerance = (/= 0) <$> wrapException (rawIsParallel a b (CDouble tolerance))
 
 -- angle
 
-foreign import capi unsafe "hs_gp_Vec2d.h hs_gp_Vec2d_Angle" rawAngle :: Ptr Vec2d -> Ptr Vec2d -> IO CDouble
+foreign import capi unsafe "hs_gp_Vec2d.h hs_gp_Vec2d_Angle" rawAngle :: Ptr Vec2d -> Ptr Vec2d -> Ptr CInt -> Ptr (Ptr ()) -> IO CDouble
 
 angle :: Ptr Vec2d -> Ptr Vec2d -> IO Double
-angle = coerce rawAngle
+angle a b = coerce <$> wrapException (rawAngle a b)
 
 
 -- magnitude

--- a/opencascade-hs/src/OpenCascade/GProp/GProps.hs
+++ b/opencascade-hs/src/OpenCascade/GProp/GProps.hs
@@ -9,35 +9,56 @@ module OpenCascade.GProp.GProps
 ) where
 
 import Foreign.Ptr (Ptr)
-import Foreign.C (CDouble (..))
+import Foreign.C (CDouble (..), CInt)
 import OpenCascade.GProp.Types (GProps)
 import OpenCascade.GProp.Internal.Destructors (deleteGProps)
 import OpenCascade.GP.Types (Pnt, Ax1)
 import OpenCascade.GP.Internal.Destructors (deletePnt)
-import Data.Acquire 
+import OpenCascade.Internal.Exception (wrapException)
+import Data.Acquire
 import Data.Coerce (coerce)
 
-foreign import capi unsafe "hs_GProp_GProps.h hs_new_GProp_GProps" rawNew :: IO (Ptr GProps)
+foreign import capi unsafe "hs_GProp_GProps.h hs_new_GProp_GProps" rawNew
+    :: Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr GProps)
 
 new :: Acquire (Ptr GProps)
-new = mkAcquire rawNew deleteGProps
+new = mkAcquire (wrapException rawNew) deleteGProps
 
-foreign import capi unsafe "hs_GProp_GProps.h hs_new_GProp_GProps_fromSystemLocation" rawFromSystemLocation :: Ptr Pnt -> IO (Ptr GProps)
+foreign import capi unsafe "hs_GProp_GProps.h hs_new_GProp_GProps_fromSystemLocation" rawFromSystemLocation
+    :: Ptr Pnt
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr GProps)
 
 fromSystemLocation :: Ptr Pnt -> Acquire (Ptr GProps)
-fromSystemLocation pnt = mkAcquire (rawFromSystemLocation pnt) deleteGProps
+fromSystemLocation pnt = mkAcquire (wrapException $ rawFromSystemLocation pnt) deleteGProps
 
-foreign import capi unsafe "hs_GProp_GProps.h hs_GProp_GProps_mass" rawMass :: Ptr GProps -> IO CDouble 
+foreign import capi unsafe "hs_GProp_GProps.h hs_GProp_GProps_mass" rawMass
+    :: Ptr GProps
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO CDouble
 
 mass :: Ptr GProps -> IO Double
-mass = coerce rawMass
+mass props = coerce <$> wrapException (rawMass props)
 
-foreign import capi unsafe "hs_GProp_GProps.h hs_GProp_GProps_centreOfMass" rawCentreOfMass :: Ptr GProps -> IO (Ptr Pnt)
+foreign import capi unsafe "hs_GProp_GProps.h hs_GProp_GProps_centreOfMass" rawCentreOfMass
+    :: Ptr GProps
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr Pnt)
 
 centreOfMass :: Ptr GProps -> Acquire (Ptr Pnt)
-centreOfMass gProps = mkAcquire (rawCentreOfMass gProps) deletePnt
+centreOfMass gProps = mkAcquire (wrapException $ rawCentreOfMass gProps) deletePnt
 
-foreign import capi unsafe "hs_GProp_GProps.h hs_GProp_GProps_momentOfInertia" rawMomentOfIntertia :: Ptr GProps -> Ptr Ax1 -> IO CDouble 
+foreign import capi unsafe "hs_GProp_GProps.h hs_GProp_GProps_momentOfInertia" rawMomentOfIntertia
+    :: Ptr GProps
+    -> Ptr Ax1
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO CDouble
 
 momentOfInertia :: Ptr GProps -> Ptr Ax1 -> IO Double
-momentOfInertia = coerce rawMomentOfIntertia
+momentOfInertia props ax = coerce <$> wrapException (rawMomentOfIntertia props ax)

--- a/opencascade-hs/src/OpenCascade/Geom/BSplineCurve.hs
+++ b/opencascade-hs/src/OpenCascade/Geom/BSplineCurve.hs
@@ -15,6 +15,7 @@ import OpenCascade.Handle (Handle)
 import OpenCascade.Internal.Bool (cBoolToBool)
 import OpenCascade.GP (Pnt)
 import OpenCascade.GP.Internal.Destructors (deletePnt)
+import OpenCascade.Internal.Exception (wrapException)
 import Data.Coerce (coerce)
 
 foreign import capi unsafe "hs_Geom_BSplineCurve.h hs_Geom_BSplineCurve_toHandle" rawToHandle :: Ptr BSplineCurve -> IO (Ptr (Handle BSplineCurve))
@@ -27,18 +28,30 @@ foreign import capi unsafe "hs_Geom_BSplineCurve.h hs_Geom_BSplineCurve_nbPoles"
 nbPoles :: Ptr (Handle (BSplineCurve)) -> IO Int 
 nbPoles h = fromIntegral <$> rawNbPoles h
 
-foreign import capi unsafe "hs_Geom_BSplineCurve.h hs_Geom_BSplineCurve_pole" rawPole :: Ptr (Handle BSplineCurve) -> CInt -> IO (Ptr Pnt)
+foreign import capi unsafe "hs_Geom_BSplineCurve.h hs_Geom_BSplineCurve_pole" rawPole
+    :: Ptr (Handle BSplineCurve)
+    -> CInt
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr Pnt)
 
 pole :: Ptr (Handle BSplineCurve) -> Int -> Acquire (Ptr Pnt)
-pole h n = mkAcquire (rawPole h (fromIntegral n)) deletePnt
+pole h n = mkAcquire (wrapException $ rawPole h (fromIntegral n)) deletePnt
 
 foreign import capi unsafe "hs_Geom_BSplineCurve.h hs_Geom_BSplineCurve_isRational" rawIsRational :: Ptr (Handle BSplineCurve) -> IO (CBool)
 
 isRational :: Ptr (Handle (BSplineCurve)) -> IO Bool
 isRational h = cBoolToBool <$> rawIsRational h
 
-foreign import capi unsafe "hs_Geom_BSplineCurve.h hs_Geom_BSplineCurve_segment" rawSegment :: Ptr (Handle BSplineCurve) -> CDouble -> CDouble -> CDouble -> IO ()
+foreign import capi unsafe "hs_Geom_BSplineCurve.h hs_Geom_BSplineCurve_segment" rawSegment
+    :: Ptr (Handle BSplineCurve)
+    -> CDouble
+    -> CDouble
+    -> CDouble
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
 
 segment :: Ptr (Handle BSplineCurve) -> Double -> Double -> Double -> IO ()
-segment = coerce rawSegment
+segment h u1 u2 confusion = wrapException $ rawSegment h (coerce u1) (coerce u2) (coerce confusion)
 

--- a/opencascade-hs/src/OpenCascade/Geom/BezierCurve.hs
+++ b/opencascade-hs/src/OpenCascade/Geom/BezierCurve.hs
@@ -18,12 +18,17 @@ import OpenCascade.GP (Pnt)
 import OpenCascade.NCollection (Array1)
 import OpenCascade.Handle (Handle)
 import OpenCascade.Internal.Bool (cBoolToBool)
+import OpenCascade.Internal.Exception (wrapException)
 
 
-foreign import capi unsafe "hs_Geom_BezierCurve.h hs_new_Geom_BezierCurve_fromPnts" rawFromPnts :: Ptr (Array1 Pnt) -> IO(Ptr BezierCurve)
+foreign import capi unsafe "hs_Geom_BezierCurve.h hs_new_Geom_BezierCurve_fromPnts" rawFromPnts
+    :: Ptr (Array1 Pnt)
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr BezierCurve)
 
 fromPnts :: Ptr (Array1 Pnt) -> Acquire (Ptr BezierCurve)
-fromPnts arr = mkAcquire (rawFromPnts arr) (deleteBezierCurve)
+fromPnts arr = mkAcquire (wrapException $ rawFromPnts arr) (deleteBezierCurve)
 
 foreign import capi unsafe "hs_Geom_BezierCurve.h hs_Geom_BezierCurve_toHandle" rawToHandle :: Ptr BezierCurve -> IO (Ptr (Handle BezierCurve))
 
@@ -36,17 +41,28 @@ foreign import capi unsafe "hs_Geom_BezierCurve.h hs_Geom_BezierCurve_nbPoles" r
 nbPoles :: Ptr (Handle (BezierCurve)) -> IO Int 
 nbPoles h = fromIntegral <$> rawNbPoles h
 
-foreign import capi unsafe "hs_Geom_BezierCurve.h hs_Geom_BezierCurve_pole" rawPole :: Ptr (Handle BezierCurve) -> CInt -> IO (Ptr Pnt)
+foreign import capi unsafe "hs_Geom_BezierCurve.h hs_Geom_BezierCurve_pole" rawPole
+    :: Ptr (Handle BezierCurve)
+    -> CInt
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr Pnt)
 
 pole :: Ptr (Handle BezierCurve) -> Int -> Acquire (Ptr Pnt)
-pole h n = mkAcquire (rawPole h (fromIntegral n)) deletePnt
+pole h n = mkAcquire (wrapException $ rawPole h (fromIntegral n)) deletePnt
 
 foreign import capi unsafe "hs_Geom_BezierCurve.h hs_Geom_BezierCurve_isRational" rawIsRational :: Ptr (Handle BezierCurve) -> IO (CBool)
 
 isRational :: Ptr (Handle (BezierCurve)) -> IO Bool
 isRational h = cBoolToBool <$> rawIsRational h
 
-foreign import capi unsafe "hs_Geom_BezierCurve.h hs_Geom_BezierCurve_segment" rawSegment :: Ptr (Handle BezierCurve) -> CDouble -> CDouble -> IO ()
+foreign import capi unsafe "hs_Geom_BezierCurve.h hs_Geom_BezierCurve_segment" rawSegment
+    :: Ptr (Handle BezierCurve)
+    -> CDouble
+    -> CDouble
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
 
 segment :: Ptr (Handle BezierCurve) -> Double -> Double -> IO ()
-segment = coerce rawSegment
+segment h u1 u2 = wrapException $ rawSegment h (coerce u1) (coerce u2)

--- a/opencascade-hs/src/OpenCascade/Geom/Curve.hs
+++ b/opencascade-hs/src/OpenCascade/Geom/Curve.hs
@@ -16,11 +16,17 @@ import OpenCascade.GP (Pnt, Vec)
 import OpenCascade.GP.Internal.Destructors (deletePnt, deleteVec)
 import OpenCascade.Geom.Internal.Destructors (deleteHandleCurve)
 import OpenCascade.Handle (Handle)
+import OpenCascade.Internal.Exception (wrapException)
 
-foreign import capi unsafe "hs_Geom_Curve.h hs_Geom_Curve_value" rawValue :: Ptr (Handle Curve) -> CDouble -> IO(Ptr Pnt)
+foreign import capi unsafe "hs_Geom_Curve.h hs_Geom_Curve_value" rawValue
+    :: Ptr (Handle Curve)
+    -> CDouble
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr Pnt)
 
 value :: Ptr (Handle Curve) -> Double -> Acquire (Ptr Pnt)
-value curve u = mkAcquire (rawValue curve (coerce u)) deletePnt
+value curve u = mkAcquire (wrapException $ rawValue curve (coerce u)) deletePnt
 
 foreign import capi unsafe "hs_Geom_Curve.h hs_Geom_Curve_firstParameter" rawFirstParameter :: Ptr (Handle Curve)-> IO (CDouble)
 
@@ -32,17 +38,32 @@ foreign import capi unsafe "hs_Geom_Curve.h hs_Geom_Curve_lastParameter" rawLast
 lastParameter :: Ptr (Handle Curve) -> IO Double
 lastParameter = coerce rawLastParameter
 
-foreign import capi unsafe "hs_Geom_Curve.h hs_Geom_Curve_dn" rawDN :: Ptr (Handle Curve) -> CDouble -> CInt -> IO (Ptr Vec)
+foreign import capi unsafe "hs_Geom_Curve.h hs_Geom_Curve_dn" rawDN
+    :: Ptr (Handle Curve)
+    -> CDouble
+    -> CInt
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr Vec)
 
 dn :: Ptr (Handle Curve) -> Double -> Int -> Acquire (Ptr Vec)
-dn curve u n = mkAcquire (rawDN curve (coerce u) (fromIntegral n)) deleteVec
+dn curve u n = mkAcquire (wrapException $ rawDN curve (coerce u) (fromIntegral n)) deleteVec
 
-foreign import capi unsafe "hs_Geom_Curve.h hs_Geom_Curve_reversedParameter" rawReversedParameter :: Ptr (Handle Curve) -> CDouble -> IO CDouble
+foreign import capi unsafe "hs_Geom_Curve.h hs_Geom_Curve_reversedParameter" rawReversedParameter
+    :: Ptr (Handle Curve)
+    -> CDouble
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO CDouble
 
 reversedParameter :: Ptr (Handle Curve) -> Double -> IO Double
-reversedParameter = coerce rawReversedParameter
+reversedParameter curve parameter = coerce <$> wrapException (rawReversedParameter curve (coerce parameter))
 
-foreign import capi unsafe "hs_Geom_Curve.h hs_Geom_Curve_reversed" rawReversed :: Ptr (Handle Curve) -> IO (Ptr (Handle Curve))
+foreign import capi unsafe "hs_Geom_Curve.h hs_Geom_Curve_reversed" rawReversed
+    :: Ptr (Handle Curve)
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr (Handle Curve))
 
 reversed :: Ptr (Handle Curve) -> Acquire (Ptr (Handle Curve))
-reversed c = mkAcquire (rawReversed c) deleteHandleCurve
+reversed c = mkAcquire (wrapException $ rawReversed c) deleteHandleCurve

--- a/opencascade-hs/src/OpenCascade/GeomAdaptor/Curve.hs
+++ b/opencascade-hs/src/OpenCascade/GeomAdaptor/Curve.hs
@@ -12,21 +12,30 @@ import qualified OpenCascade.Geom.Types as Geom
 import qualified OpenCascade.Geom.Internal.Destructors as Geom.Destructors
 import OpenCascade.GeomAdaptor.Internal.Destructors (deleteCurve)
 import OpenCascade.Handle (Handle)
-import Foreign.C (CDouble (..))
+import OpenCascade.Internal.Exception (wrapException)
+import Foreign.C (CDouble (..), CInt)
 import Data.Coerce (coerce)
-import Foreign.Ptr 
+import Foreign.Ptr
 import Data.Acquire (Acquire, mkAcquire)
 
-foreign import capi unsafe "hs_GeomAdaptor_Curve.h hs_new_GeomAdaptor_Curve_fromHandle" rawFromHandle :: Ptr (Handle Geom.Curve) -> IO (Ptr Curve)
+foreign import capi unsafe "hs_GeomAdaptor_Curve.h hs_new_GeomAdaptor_Curve_fromHandle" rawFromHandle
+    :: Ptr (Handle Geom.Curve)
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr Curve)
 
 fromHandle :: Ptr (Handle Geom.Curve) -> Acquire (Ptr Curve)
-fromHandle h = mkAcquire (rawFromHandle h) deleteCurve
+fromHandle h = mkAcquire (wrapException $ rawFromHandle h) deleteCurve
 
 
-foreign import capi unsafe "hs_GeomAdaptor_Curve.h hs_GeomAdaptor_Curve_curve" rawCurve :: Ptr Curve -> IO (Ptr (Handle Geom.Curve))
+foreign import capi unsafe "hs_GeomAdaptor_Curve.h hs_GeomAdaptor_Curve_curve" rawCurve
+    :: Ptr Curve
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr (Handle Geom.Curve))
 
 curve :: Ptr Curve -> Acquire (Ptr (Handle Geom.Curve))
-curve adaptor = mkAcquire (rawCurve adaptor) Geom.Destructors.deleteHandleCurve
+curve adaptor = mkAcquire (wrapException $ rawCurve adaptor) Geom.Destructors.deleteHandleCurve
 
 foreign import capi unsafe "hs_GeomAdaptor_Curve.h hs_GeomAdaptor_Curve_firstParameter" rawFirstParameter :: Ptr Curve-> IO (CDouble)
 

--- a/opencascade-hs/src/OpenCascade/GeomConvert/ApproxCurve.hs
+++ b/opencascade-hs/src/OpenCascade/GeomConvert/ApproxCurve.hs
@@ -18,25 +18,38 @@ import Data.Acquire (Acquire, mkAcquire)
 import OpenCascade.Handle (Handle)
 import OpenCascade.Geom.Types as Geom
 import OpenCascade.Internal.Bool (cBoolToBool)
+import OpenCascade.Internal.Exception (wrapException)
 
-foreign import capi unsafe "hs_GeomConvert_ApproxCurve.h hs_new_GeomConvert_ApproxCurve_fromCurveToleranceOrderSegmentsAndDegree" rawFromCurveToleranceOrderSegmentsAndDegree :: Ptr (Handle Geom.Curve) -> CDouble -> CInt -> CInt -> CInt -> IO (Ptr ApproxCurve)
+foreign import capi unsafe "hs_GeomConvert_ApproxCurve.h hs_new_GeomConvert_ApproxCurve_fromCurveToleranceOrderSegmentsAndDegree" rawFromCurveToleranceOrderSegmentsAndDegree
+    :: Ptr (Handle Geom.Curve)
+    -> CDouble
+    -> CInt
+    -> CInt
+    -> CInt
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr ApproxCurve)
 
 fromCurveToleranceOrderSegmentsAndDegree :: Ptr (Handle Geom.Curve) -> Double -> GeomAbs.Shape.Shape -> Int -> Int -> Acquire (Ptr ApproxCurve)
-fromCurveToleranceOrderSegmentsAndDegree theCurve tolerance order maxSegments maxDegree = 
-    mkAcquire 
-        (rawFromCurveToleranceOrderSegmentsAndDegree 
+fromCurveToleranceOrderSegmentsAndDegree theCurve tolerance order maxSegments maxDegree =
+    mkAcquire
+        (wrapException $ rawFromCurveToleranceOrderSegmentsAndDegree
             theCurve
             (coerce tolerance)
             (fromIntegral . fromEnum $ order)
             (fromIntegral maxSegments)
-            (fromIntegral maxDegree)) 
+            (fromIntegral maxDegree))
         deleteApproxCurve
 
 
-foreign import capi unsafe "hs_GeomConvert_ApproxCurve.h hs_GeomConvert_ApproxCurve_curve" rawCurve :: Ptr ApproxCurve -> IO (Ptr (Handle Geom.BSplineCurve))
+foreign import capi unsafe "hs_GeomConvert_ApproxCurve.h hs_GeomConvert_ApproxCurve_curve" rawCurve
+    :: Ptr ApproxCurve
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr (Handle Geom.BSplineCurve))
 
 curve :: Ptr ApproxCurve -> Acquire (Ptr (Handle Geom.BSplineCurve))
-curve approxCurve = mkAcquire (rawCurve approxCurve) deleteHandleBSplineCurve
+curve approxCurve = mkAcquire (wrapException $ rawCurve approxCurve) deleteHandleBSplineCurve
 
 foreign import capi unsafe "hs_GeomConvert_ApproxCurve.h hs_GeomConvert_ApproxCurve_isDone" rawIsDone :: Ptr ApproxCurve -> IO (CBool)
 

--- a/opencascade-hs/src/OpenCascade/GeomConvert/BSplineCurveToBezierCurve.hs
+++ b/opencascade-hs/src/OpenCascade/GeomConvert/BSplineCurveToBezierCurve.hs
@@ -12,27 +12,44 @@ import OpenCascade.GeomConvert.Internal.Destructors (deleteBSplineCurveToBezierC
 import OpenCascade.Geom.Internal.Destructors (deleteHandleBezierCurve)
 import qualified OpenCascade.Geom.Types as Geom
 import OpenCascade.Handle (Handle)
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.Ptr (Ptr)
 import Foreign.C (CInt (..), CDouble (..))
 import Data.Coerce (coerce)
 import Data.Acquire (Acquire, mkAcquire)
 
-foreign import capi unsafe "hs_GeomConvert_BSplineCurveToBezierCurve.h hs_new_GeomConvert_BSplineCurveToBezierCurve_fromHandle" rawFromHandle :: Ptr (Handle Geom.BSplineCurve) -> IO(Ptr BSplineCurveToBezierCurve)
+foreign import capi unsafe "hs_GeomConvert_BSplineCurveToBezierCurve.h hs_new_GeomConvert_BSplineCurveToBezierCurve_fromHandle" rawFromHandle
+    :: Ptr (Handle Geom.BSplineCurve)
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr BSplineCurveToBezierCurve)
 
 fromHandle :: Ptr (Handle Geom.BSplineCurve) -> Acquire (Ptr BSplineCurveToBezierCurve)
-fromHandle h = mkAcquire (rawFromHandle h) (deleteBSplineCurveToBezierCurve)
+fromHandle h = mkAcquire (wrapException $ rawFromHandle h) (deleteBSplineCurveToBezierCurve)
 
-foreign import capi unsafe "hs_GeomConvert_BSplineCurveToBezierCurve.h hs_new_GeomConvert_BSplineCurveToBezierCurve_fromHandleParametersAndTolerance" rawFromHandleParametersAndTolerance :: Ptr (Handle Geom.BSplineCurve) -> CDouble -> CDouble -> CDouble -> IO(Ptr BSplineCurveToBezierCurve)
+foreign import capi unsafe "hs_GeomConvert_BSplineCurveToBezierCurve.h hs_new_GeomConvert_BSplineCurveToBezierCurve_fromHandleParametersAndTolerance" rawFromHandleParametersAndTolerance
+    :: Ptr (Handle Geom.BSplineCurve)
+    -> CDouble
+    -> CDouble
+    -> CDouble
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr BSplineCurveToBezierCurve)
 
 fromHandleParametersAndTolerance :: Ptr (Handle Geom.BSplineCurve) -> Double -> Double -> Double -> Acquire (Ptr BSplineCurveToBezierCurve)
-fromHandleParametersAndTolerance h firstParam secondParam tolerance= mkAcquire (rawFromHandleParametersAndTolerance h (coerce firstParam) (coerce secondParam) (coerce tolerance)) (deleteBSplineCurveToBezierCurve)
+fromHandleParametersAndTolerance h firstParam secondParam tolerance= mkAcquire (wrapException $ rawFromHandleParametersAndTolerance h (coerce firstParam) (coerce secondParam) (coerce tolerance)) (deleteBSplineCurveToBezierCurve)
 
 foreign import capi unsafe "hs_GeomConvert_BSplineCurveToBezierCurve.h hs_GeomConvert_BSplineCurveToBezierCurve_nbArcs" rawNbArcs :: Ptr (BSplineCurveToBezierCurve) -> IO CInt
 
 nbArcs :: Ptr BSplineCurveToBezierCurve -> IO Int
 nbArcs p = fromIntegral <$> rawNbArcs p
 
-foreign import capi unsafe "hs_GeomConvert_BSplineCurveToBezierCurve.h hs_GeomConvert_BSplineCurveToBezierCurve_arc" rawArc :: Ptr (BSplineCurveToBezierCurve) -> CInt -> IO (Ptr (Handle Geom.BezierCurve))
+foreign import capi unsafe "hs_GeomConvert_BSplineCurveToBezierCurve.h hs_GeomConvert_BSplineCurveToBezierCurve_arc" rawArc
+    :: Ptr (BSplineCurveToBezierCurve)
+    -> CInt
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr (Handle Geom.BezierCurve))
 
 arc :: Ptr BSplineCurveToBezierCurve -> Int -> Acquire (Ptr (Handle Geom.BezierCurve))
-arc p n = mkAcquire (rawArc p (fromIntegral n)) deleteHandleBezierCurve
+arc p n = mkAcquire (wrapException $ rawArc p (fromIntegral n)) deleteHandleBezierCurve

--- a/opencascade-hs/src/OpenCascade/HLRBRep/Algo.hs
+++ b/opencascade-hs/src/OpenCascade/HLRBRep/Algo.hs
@@ -11,7 +11,9 @@ import OpenCascade.HLRBRep.Types (Algo)
 import qualified OpenCascade.HLRAlgo.Types as HLRAlgo
 import qualified OpenCascade.TopoDS.Types as TopoDS
 import OpenCascade.HLRBRep.Internal.Destructors (deleteAlgo)
-import Foreign.Ptr 
+import OpenCascade.Internal.Exception (wrapException)
+import Foreign.C (CInt)
+import Foreign.Ptr
 import Data.Acquire (mkAcquire, Acquire)
 import OpenCascade.Handle
 
@@ -22,8 +24,30 @@ new = mkAcquire rawNew deleteAlgo
 
 foreign import capi unsafe "hs_HLRBRep_Algo.h hs_HLRBRep_Algo_projector" projector :: Ptr (Handle Algo) -> Ptr HLRAlgo.Projector -> IO ()
 
-foreign import capi unsafe "hs_HLRBRep_Algo.h hs_HLRBRep_Algo_add" add :: Ptr (Handle Algo) -> Ptr TopoDS.Shape -> IO ()
+foreign import capi unsafe "hs_HLRBRep_Algo.h hs_HLRBRep_Algo_add" rawAdd
+    :: Ptr (Handle Algo)
+    -> Ptr TopoDS.Shape
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
 
-foreign import capi unsafe "hs_HLRBRep_Algo.h hs_HLRBRep_Algo_update" update :: Ptr (Handle Algo) -> IO ()
+add :: Ptr (Handle Algo) -> Ptr TopoDS.Shape -> IO ()
+add algo shape = wrapException $ rawAdd algo shape
 
-foreign import capi unsafe "hs_HLRBRep_Algo.h hs_HLRBRep_Algo_hide" hide :: Ptr (Handle Algo) -> IO ()
+foreign import capi unsafe "hs_HLRBRep_Algo.h hs_HLRBRep_Algo_update" rawUpdate
+    :: Ptr (Handle Algo)
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
+
+update :: Ptr (Handle Algo) -> IO ()
+update algo = wrapException $ rawUpdate algo
+
+foreign import capi unsafe "hs_HLRBRep_Algo.h hs_HLRBRep_Algo_hide" rawHide
+    :: Ptr (Handle Algo)
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
+
+hide :: Ptr (Handle Algo) -> IO ()
+hide algo = wrapException $ rawHide algo

--- a/opencascade-hs/src/OpenCascade/HLRBRep/HLRToShape.hs
+++ b/opencascade-hs/src/OpenCascade/HLRBRep/HLRToShape.hs
@@ -15,16 +15,28 @@ import Data.Acquire (mkAcquire, Acquire)
 import OpenCascade.Handle
 import Foreign.C (CInt (..), CBool (..))
 import OpenCascade.Internal.Bool (boolToCBool)
+import OpenCascade.Internal.Exception (wrapException)
 
-foreign import capi unsafe "hs_HLRBRep_HLRToShape.h hs_new_HLRBRep_HLRToShape_fromHandleAlgo" rawFromHandleAlgo :: Ptr (Handle Algo) -> IO (Ptr HLRToShape)
+foreign import capi unsafe "hs_HLRBRep_HLRToShape.h hs_new_HLRBRep_HLRToShape_fromHandleAlgo" rawFromHandleAlgo
+    :: Ptr (Handle Algo)
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr HLRToShape)
 
 fromAlgo :: Ptr (Handle Algo) -> Acquire (Ptr HLRToShape)
-fromAlgo algo = mkAcquire (rawFromHandleAlgo algo) deleteHLRToShape
+fromAlgo algo = mkAcquire (wrapException $ rawFromHandleAlgo algo) deleteHLRToShape
 
-foreign import capi unsafe "hs_HLRBRep_HLRToShape.h hs_HLRBRep_HLRToShape_compoundOfEdges" rawCompoundOfEdges :: Ptr HLRToShape -> CInt -> CBool -> CBool -> IO (Ptr TopoDS.Shape)
+foreign import capi unsafe "hs_HLRBRep_HLRToShape.h hs_HLRBRep_HLRToShape_compoundOfEdges" rawCompoundOfEdges
+    :: Ptr HLRToShape
+    -> CInt
+    -> CBool
+    -> CBool
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Shape)
 
 compoundOfEdges :: Ptr HLRToShape -> TypeOfResultingEdge -> Bool -> Bool -> Acquire (Ptr TopoDS.Shape)
 compoundOfEdges hlrToShape typeOfEdge visible in3d =
-    mkAcquire 
-        (rawCompoundOfEdges hlrToShape (fromIntegral . fromEnum $ typeOfEdge) (boolToCBool visible) (boolToCBool in3d))
+    mkAcquire
+        (wrapException $ rawCompoundOfEdges hlrToShape (fromIntegral . fromEnum $ typeOfEdge) (boolToCBool visible) (boolToCBool in3d))
         deleteShape

--- a/opencascade-hs/src/OpenCascade/Internal/Exception.hs
+++ b/opencascade-hs/src/OpenCascade/Internal/Exception.hs
@@ -5,12 +5,48 @@ module OpenCascade.Internal.Exception
 import Foreign.C
 import Foreign.Ptr
 import Foreign.Marshal (alloca)
+import Control.Exception (Exception, throw)
+import Data.Data (Typeable)
+import Foreign.Storable (peek)
+import qualified OpenCascade.Standard.Failure as Standard.Failure
+import OpenCascade.Inheritance (upcast)
+import qualified OpenCascade.Std.Exception as Std.Exception
+import OpenCascade.Standard.Internal.Destructors (deleteFailure)
+import OpenCascade.Std.Internal.Destructors (deleteException)
+
 -- This needs to stay consistent with the ordering in hs_Exception.h
 data ExceptionType = NoException | StandardFailureException | StdException | OtherException 
     deriving (Show, Eq, Ord, Enum, Bounded)
+
+data OpenCascadeException 
+    = OpenCascadeStandardFailure String String
+    | OpenCascadeStdException String
+    | OpenCascadeOtherException
+    deriving (Eq, Ord, Typeable, Show)
+
+instance Exception OpenCascadeException
+
+handleError :: Ptr CInt -> Ptr (Ptr ()) -> IO ()
+handleError flagPtr exPtr = do
+    flag <- peek flagPtr
+    case toEnum . fromIntegral $ flag of 
+        NoException -> pure ()
+        StandardFailureException -> do
+            stdFailure <- castPtr <$> peek exPtr
+            msgString <- peekCString =<< Std.Exception.what (upcast stdFailure)
+            stackString <- peekCString =<< Standard.Failure.getStackString stdFailure
+            deleteFailure stdFailure
+            throw (OpenCascadeStandardFailure msgString stackString)
+        StdException -> do
+            stdException <- castPtr <$> peek exPtr
+            msgString <- peekCString =<< Std.Exception.what stdException
+            deleteException stdException
+            throw (OpenCascadeStdException msgString)
+        OtherException -> do
+            throw OpenCascadeOtherException
 
 wrapException :: (Ptr CInt -> Ptr (Ptr ()) -> IO a) -> IO a
 wrapException f =
     alloca $ \flagPtr -> 
         alloca $ \exPtr -> do
-            f flagPtr exPtr
+            f flagPtr exPtr <* handleError flagPtr exPtr

--- a/opencascade-hs/src/OpenCascade/Internal/Exception.hs
+++ b/opencascade-hs/src/OpenCascade/Internal/Exception.hs
@@ -1,0 +1,16 @@
+module OpenCascade.Internal.Exception 
+( wrapException
+) where
+
+import Foreign.C
+import Foreign.Ptr
+import Foreign.Marshal (alloca)
+-- This needs to stay consistent with the ordering in hs_Exception.h
+data ExceptionType = NoException | StandardFailureException | StdException | OtherException 
+    deriving (Show, Eq, Ord, Enum, Bounded)
+
+wrapException :: (Ptr CInt -> Ptr (Ptr ()) -> IO a) -> IO a
+wrapException f =
+    alloca $ \flagPtr -> 
+        alloca $ \exPtr -> do
+            f flagPtr exPtr

--- a/opencascade-hs/src/OpenCascade/Internal/Exception.hs
+++ b/opencascade-hs/src/OpenCascade/Internal/Exception.hs
@@ -26,6 +26,12 @@ data OpenCascadeException
 
 instance Exception OpenCascadeException
 
+safePeekCString :: Ptr CChar -> IO String
+safePeekCString ptr = 
+    if ptr == nullPtr
+        then pure ""
+        else peekCString ptr
+
 handleError :: Ptr CInt -> Ptr (Ptr ()) -> IO ()
 handleError flagPtr exPtr = do
     flag <- peek flagPtr
@@ -33,13 +39,13 @@ handleError flagPtr exPtr = do
         NoException -> pure ()
         StandardFailureException -> do
             stdFailure <- castPtr <$> peek exPtr
-            msgString <- peekCString =<< Standard.Failure.getMessageString stdFailure
-            stackString <- peekCString =<< Standard.Failure.getStackString stdFailure
+            msgString <- safePeekCString =<< Standard.Failure.getMessageString stdFailure
+            stackString <- safePeekCString =<< Standard.Failure.getStackString stdFailure
             deleteFailure stdFailure
             throw (OpenCascadeStandardFailure msgString stackString)
         StdException -> do
             stdException <- castPtr <$> peek exPtr
-            msgString <- peekCString =<< Std.Exception.what stdException
+            msgString <- safePeekCString =<< Std.Exception.what stdException
             deleteException stdException
             throw (OpenCascadeStdException msgString)
         OtherException -> do

--- a/opencascade-hs/src/OpenCascade/Internal/Exception.hs
+++ b/opencascade-hs/src/OpenCascade/Internal/Exception.hs
@@ -1,5 +1,6 @@
 module OpenCascade.Internal.Exception 
-( wrapException
+( OpenCascadeException (..)
+, wrapException
 ) where
 
 import Foreign.C
@@ -9,7 +10,6 @@ import Control.Exception (Exception, throw)
 import Data.Data (Typeable)
 import Foreign.Storable (peek)
 import qualified OpenCascade.Standard.Failure as Standard.Failure
-import OpenCascade.Inheritance (upcast)
 import qualified OpenCascade.Std.Exception as Std.Exception
 import OpenCascade.Standard.Internal.Destructors (deleteFailure)
 import OpenCascade.Std.Internal.Destructors (deleteException)
@@ -33,7 +33,7 @@ handleError flagPtr exPtr = do
         NoException -> pure ()
         StandardFailureException -> do
             stdFailure <- castPtr <$> peek exPtr
-            msgString <- peekCString =<< Std.Exception.what (upcast stdFailure)
+            msgString <- peekCString =<< Standard.Failure.getMessageString stdFailure
             stackString <- peekCString =<< Standard.Failure.getStackString stdFailure
             deleteFailure stdFailure
             throw (OpenCascadeStandardFailure msgString stackString)

--- a/opencascade-hs/src/OpenCascade/Internal/Exception.hs
+++ b/opencascade-hs/src/OpenCascade/Internal/Exception.hs
@@ -1,6 +1,8 @@
+{-# LANGUAGE CApiFFI #-}
 module OpenCascade.Internal.Exception 
 ( OpenCascadeException (..)
 , wrapException
+, testThrow
 ) where
 
 import Foreign.C
@@ -10,6 +12,7 @@ import Control.Exception (Exception, throw)
 import Data.Data (Typeable)
 import Foreign.Storable (peek)
 import qualified OpenCascade.Standard.Failure as Standard.Failure
+import qualified OpenCascade.Std.Types as Std
 import qualified OpenCascade.Std.Exception as Std.Exception
 import OpenCascade.Standard.Internal.Destructors (deleteFailure)
 import OpenCascade.Std.Internal.Destructors (deleteException)
@@ -56,3 +59,9 @@ wrapException f =
     alloca $ \flagPtr -> 
         alloca $ \exPtr -> do
             f flagPtr exPtr <* handleError flagPtr exPtr
+
+foreign import capi unsafe "hs_Exception.h hs_throw_std_exception" rawThrow :: Ptr Std.Exception -> Ptr CInt -> Ptr (Ptr ())-> IO ()
+
+-- | This is exposed in order to write tests for the Std.Exception catching path
+testThrow :: Ptr Std.Exception -> IO ()
+testThrow ex = wrapException (rawThrow ex)

--- a/opencascade-hs/src/OpenCascade/NCollection/Array1.hs
+++ b/opencascade-hs/src/OpenCascade/NCollection/Array1.hs
@@ -11,13 +11,25 @@ import Foreign.C
 import OpenCascade.GP.Types
 import OpenCascade.NCollection.Types
 import OpenCascade.NCollection.Internal.Destructors
+import OpenCascade.Internal.Exception (wrapException)
 
-foreign import capi unsafe "hs_NCollection_Array1.h hs_new_NCollection_Array1_gp_Pnt" rawNewGPPntArray :: CInt -> CInt -> IO (Ptr (Array1 Pnt))
+foreign import capi unsafe "hs_NCollection_Array1.h hs_new_NCollection_Array1_gp_Pnt" rawNewGPPntArray
+    :: CInt
+    -> CInt
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr (Array1 Pnt))
 
 newGPPntArray :: Int -> Int -> Acquire (Ptr (Array1 Pnt))
-newGPPntArray lo hi = mkAcquire (rawNewGPPntArray (fromIntegral lo) (fromIntegral hi)) deletePntArray
+newGPPntArray lo hi = mkAcquire (wrapException $ rawNewGPPntArray (fromIntegral lo) (fromIntegral hi)) deletePntArray
 
-foreign import capi unsafe "hs_NCollection_Array1.h hs_NCollection_Array1_gp_Pnt_setValue" rawSetValueGPPnt :: Ptr (Array1 Pnt) -> CInt -> Ptr Pnt -> IO ()
+foreign import capi unsafe "hs_NCollection_Array1.h hs_NCollection_Array1_gp_Pnt_setValue" rawSetValueGPPnt
+    :: Ptr (Array1 Pnt)
+    -> CInt
+    -> Ptr Pnt
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
 
 setValueGPPnt :: Ptr (Array1 Pnt) -> Int -> Ptr Pnt -> IO ()
-setValueGPPnt arr i p = rawSetValueGPPnt arr (fromIntegral i) p
+setValueGPPnt arr i p = wrapException $ rawSetValueGPPnt arr (fromIntegral i) p

--- a/opencascade-hs/src/OpenCascade/Poly/Triangle.hs
+++ b/opencascade-hs/src/OpenCascade/Poly/Triangle.hs
@@ -8,6 +8,7 @@ module OpenCascade.Poly.Triangle
 
 import OpenCascade.Poly.Types (Triangle)
 import OpenCascade.Poly.Internal.Destructors (deleteTriangle)
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.C (CInt (..))
 import Foreign.Ptr (Ptr)
 import Data.Acquire (Acquire, mkAcquire)
@@ -17,12 +18,23 @@ foreign import capi unsafe "hs_Poly_Triangle.h hs_new_Poly_Triangle_fromIndices"
 fromIndices :: Int -> Int -> Int -> Acquire (Ptr Triangle)
 fromIndices n1 n2 n3 = mkAcquire (rawFromIndices (fromIntegral n1) (fromIntegral n2) (fromIntegral n3)) deleteTriangle
 
-foreign import capi unsafe "hs_Poly_Triangle.h hs_Poly_Triangle_value" rawValue :: Ptr Triangle -> CInt -> IO CInt
+foreign import capi unsafe "hs_Poly_Triangle.h hs_Poly_Triangle_value" rawValue
+    :: Ptr Triangle
+    -> CInt
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO CInt
 
 value :: Ptr Triangle -> Int -> IO Int
-value tri index = fromIntegral <$> rawValue tri (fromIntegral index)
+value tri index = fromIntegral <$> wrapException (rawValue tri (fromIntegral index))
 
-foreign import capi unsafe "hs_Poly_Triangle.h hs_Poly_Triangle_setValue" rawSetValue :: Ptr Triangle -> CInt -> CInt -> IO ()
+foreign import capi unsafe "hs_Poly_Triangle.h hs_Poly_Triangle_setValue" rawSetValue
+    :: Ptr Triangle
+    -> CInt
+    -> CInt
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
 
 setValue :: Ptr Triangle -> Int -> Int -> IO ()
-setValue tri index node = rawSetValue tri (fromIntegral index) (fromIntegral node)
+setValue tri index node = wrapException $ rawSetValue tri (fromIntegral index) (fromIntegral node)

--- a/opencascade-hs/src/OpenCascade/Poly/Triangulation.hs
+++ b/opencascade-hs/src/OpenCascade/Poly/Triangulation.hs
@@ -18,12 +18,20 @@ import OpenCascade.Handle (Handle)
 import Foreign.Ptr (Ptr)
 import Foreign.C (CInt (..), CBool (..))
 import OpenCascade.Internal.Bool (boolToCBool)
+import OpenCascade.Internal.Exception (wrapException)
 import Data.Acquire (Acquire, mkAcquire)
 
-foreign import capi unsafe "hs_Poly_Triangulation.h hs_new_Poly_Triangulation" rawNew :: CInt -> CInt -> CBool -> CBool -> IO (Ptr (Handle Triangulation))
+foreign import capi unsafe "hs_Poly_Triangulation.h hs_new_Poly_Triangulation" rawNew
+    :: CInt
+    -> CInt
+    -> CBool
+    -> CBool
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr (Handle Triangulation))
 
 new :: Int -> Int -> Bool -> Bool -> Acquire (Ptr (Handle Triangulation))
-new nNodes nTriangles hasUVNodes hasNormals = mkAcquire (rawNew (fromIntegral nNodes) (fromIntegral nTriangles) (boolToCBool hasUVNodes) (boolToCBool hasNormals)) deleteHandleTriangulation
+new nNodes nTriangles hasUVNodes hasNormals = mkAcquire (wrapException $ rawNew (fromIntegral nNodes) (fromIntegral nTriangles) (boolToCBool hasUVNodes) (boolToCBool hasNormals)) deleteHandleTriangulation
 
 foreign import capi unsafe "hs_Poly_Triangulation.h hs_Poly_Triangulation_nbNodes" rawNbNodes :: Ptr (Handle Triangulation) -> IO CInt
 
@@ -35,22 +43,44 @@ foreign import capi unsafe "hs_Poly_Triangulation.h hs_Poly_Triangulation_nbTria
 nbTriangles :: Ptr (Handle Triangulation) -> IO Int
 nbTriangles tri = fromIntegral <$> rawNbTriangles tri
 
-foreign import capi unsafe "hs_Poly_Triangulation.h hs_Poly_Triangulation_node" rawNode :: Ptr (Handle Triangulation) -> CInt -> IO (Ptr GP.Pnt)
+foreign import capi unsafe "hs_Poly_Triangulation.h hs_Poly_Triangulation_node" rawNode
+    :: Ptr (Handle Triangulation)
+    -> CInt
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr GP.Pnt)
 
 node :: Ptr (Handle Triangulation) -> Int -> Acquire (Ptr GP.Pnt)
-node tri index = mkAcquire (rawNode tri (fromIntegral index)) deletePnt
+node tri index = mkAcquire (wrapException $ rawNode tri (fromIntegral index)) deletePnt
 
-foreign import capi unsafe "hs_Poly_Triangulation.h hs_Poly_Triangulation_setNode" rawSetNode :: Ptr (Handle Triangulation) -> CInt -> Ptr GP.Pnt -> IO()
+foreign import capi unsafe "hs_Poly_Triangulation.h hs_Poly_Triangulation_setNode" rawSetNode
+    :: Ptr (Handle Triangulation)
+    -> CInt
+    -> Ptr GP.Pnt
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
 
 setNode :: Ptr (Handle Triangulation) -> Int -> Ptr GP.Pnt -> IO ()
-setNode tri index pnt = rawSetNode tri (fromIntegral index) pnt
+setNode tri index pnt = wrapException $ rawSetNode tri (fromIntegral index) pnt
 
-foreign import capi unsafe "hs_Poly_Triangulation.h hs_Poly_Triangulation_triangle" rawTriangle :: Ptr (Handle Triangulation) -> CInt -> IO (Ptr Triangle)
+foreign import capi unsafe "hs_Poly_Triangulation.h hs_Poly_Triangulation_triangle" rawTriangle
+    :: Ptr (Handle Triangulation)
+    -> CInt
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr Triangle)
 
 triangle :: Ptr (Handle Triangulation) -> Int -> Acquire (Ptr Triangle)
-triangle tri index = mkAcquire (rawTriangle tri (fromIntegral index)) deleteTriangle
+triangle tri index = mkAcquire (wrapException $ rawTriangle tri (fromIntegral index)) deleteTriangle
 
-foreign import capi unsafe "hs_Poly_Triangulation.h hs_Poly_Triangulation_setTriangle" rawSetTriangle :: Ptr (Handle Triangulation) -> CInt -> Ptr Triangle -> IO ()
+foreign import capi unsafe "hs_Poly_Triangulation.h hs_Poly_Triangulation_setTriangle" rawSetTriangle
+    :: Ptr (Handle Triangulation)
+    -> CInt
+    -> Ptr Triangle
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
 
 setTriangle :: Ptr (Handle Triangulation) -> Int -> Ptr Triangle -> IO ()
-setTriangle tri index theTriangle = rawSetTriangle tri (fromIntegral index) theTriangle 
+setTriangle tri index theTriangle = wrapException $ rawSetTriangle tri (fromIntegral index) theTriangle

--- a/opencascade-hs/src/OpenCascade/RWGltf/CafWriter.hs
+++ b/opencascade-hs/src/OpenCascade/RWGltf/CafWriter.hs
@@ -9,9 +9,10 @@ import OpenCascade.RWGltf.Types (CafWriter)
 import OpenCascade.RWGltf.Internal.Destructors (deleteCafWriter)
 import Foreign.Ptr (Ptr)
 import Foreign.C.String (CString, withCString)
-import Foreign.C (CBool (..))
+import Foreign.C (CBool (..), CInt)
 import Data.Acquire (Acquire, mkAcquire)
 import OpenCascade.Internal.Bool (boolToCBool)
+import OpenCascade.Internal.Exception (wrapException)
 import OpenCascade.Handle (Handle)
 import qualified OpenCascade.TDocStd.Types as TDocStd
 import qualified OpenCascade.TColStd.Types as TColStd
@@ -22,4 +23,14 @@ foreign import capi unsafe "hs_RWGltf_CafWriter.h hs_new_RWGltf_CafWriter" rawNe
 new :: String -> Bool -> Acquire (Ptr CafWriter)
 new filepath binary = mkAcquire (withCString filepath $ \str -> rawNew str (boolToCBool binary)) deleteCafWriter
 
-foreign import capi unsafe "hs_RWGltf_CafWriter.h hs_RWGltf_CafWriter_Perform" perform :: Ptr CafWriter -> Ptr (Handle TDocStd.Document) -> Ptr (TColStd.IndexedDataMapOfStringString) -> Ptr (Message.ProgressRange) -> IO ()
+foreign import capi unsafe "hs_RWGltf_CafWriter.h hs_RWGltf_CafWriter_Perform" rawPerform
+    :: Ptr CafWriter
+    -> Ptr (Handle TDocStd.Document)
+    -> Ptr (TColStd.IndexedDataMapOfStringString)
+    -> Ptr (Message.ProgressRange)
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
+
+perform :: Ptr CafWriter -> Ptr (Handle TDocStd.Document) -> Ptr (TColStd.IndexedDataMapOfStringString) -> Ptr (Message.ProgressRange) -> IO ()
+perform writer doc fileInfo progress = wrapException $ rawPerform writer doc fileInfo progress

--- a/opencascade-hs/src/OpenCascade/RWMesh/CafReader.hs
+++ b/opencascade-hs/src/OpenCascade/RWMesh/CafReader.hs
@@ -14,7 +14,8 @@ import qualified OpenCascade.TopoDS.Types as TopoDS
 import OpenCascade.TopoDS.Internal.Destructors (deleteShape)
 import OpenCascade.Handle (Handle)
 import OpenCascade.Internal.Bool (cBoolToBool)
-import Foreign.C (CBool (..), CDouble (..))
+import OpenCascade.Internal.Exception (wrapException)
+import Foreign.C (CBool (..), CDouble (..), CInt)
 import Foreign.C.String (CString, withCString)
 import Foreign.Ptr (Ptr)
 import Data.Coerce (coerce)
@@ -27,13 +28,23 @@ foreign import capi unsafe "hs_RWMesh_CafReader.h hs_RWMesh_CafReader_setFileLen
 setFileLengthUnit :: Ptr CafReader -> Double -> IO ()
 setFileLengthUnit = coerce rawSetFileLengthUnit
 
-foreign import capi unsafe "hs_RWMesh_CafReader.h hs_RWMesh_CafReader_perform" rawPerform :: Ptr CafReader -> CString -> Ptr Message.ProgressRange -> IO CBool
+foreign import capi unsafe "hs_RWMesh_CafReader.h hs_RWMesh_CafReader_perform" rawPerform
+    :: Ptr CafReader
+    -> CString
+    -> Ptr Message.ProgressRange
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO CBool
 
 perform :: Ptr CafReader -> String -> Ptr Message.ProgressRange -> IO Bool
-perform reader filename progress = cBoolToBool <$> (withCString filename $ \str -> rawPerform reader str progress)
+perform reader filename progress = cBoolToBool <$> (withCString filename $ \str -> wrapException $ rawPerform reader str progress)
 
-foreign import capi unsafe "hs_RWMesh_CafReader.h hs_RWMesh_CafReader_singleShape" rawSingleShape :: Ptr CafReader -> IO (Ptr TopoDS.Shape)
+foreign import capi unsafe "hs_RWMesh_CafReader.h hs_RWMesh_CafReader_singleShape" rawSingleShape
+    :: Ptr CafReader
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Shape)
 
 singleShape :: Ptr CafReader -> Acquire (Ptr TopoDS.Shape)
-singleShape reader = mkAcquire (rawSingleShape reader) deleteShape
+singleShape reader = mkAcquire (wrapException $ rawSingleShape reader) deleteShape
 

--- a/opencascade-hs/src/OpenCascade/RWObj/CafWriter.hs
+++ b/opencascade-hs/src/OpenCascade/RWObj/CafWriter.hs
@@ -9,7 +9,9 @@ import OpenCascade.RWObj.Types (CafWriter)
 import OpenCascade.RWObj.Internal.Destructors (deleteCafWriter)
 import Foreign.Ptr (Ptr)
 import Foreign.C.String (CString, withCString)
+import Foreign.C (CInt)
 import Data.Acquire (Acquire, mkAcquire)
+import OpenCascade.Internal.Exception (wrapException)
 import OpenCascade.Handle (Handle)
 import qualified OpenCascade.TDocStd.Types as TDocStd
 import qualified OpenCascade.TColStd.Types as TColStd
@@ -20,4 +22,14 @@ foreign import capi unsafe "hs_RWObj_CafWriter.h hs_new_RWObj_CafWriter" rawNew 
 new :: String -> Acquire (Ptr CafWriter)
 new filepath = mkAcquire (withCString filepath rawNew) deleteCafWriter
 
-foreign import capi unsafe "hs_RWObj_CafWriter.h hs_RWObj_CafWriter_Perform" perform :: Ptr CafWriter -> Ptr (Handle TDocStd.Document) -> Ptr (TColStd.IndexedDataMapOfStringString) -> Ptr (Message.ProgressRange) -> IO ()
+foreign import capi unsafe "hs_RWObj_CafWriter.h hs_RWObj_CafWriter_Perform" rawPerform
+    :: Ptr CafWriter
+    -> Ptr (Handle TDocStd.Document)
+    -> Ptr (TColStd.IndexedDataMapOfStringString)
+    -> Ptr (Message.ProgressRange)
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
+
+perform :: Ptr CafWriter -> Ptr (Handle TDocStd.Document) -> Ptr (TColStd.IndexedDataMapOfStringString) -> Ptr (Message.ProgressRange) -> IO ()
+perform writer doc fileInfo progress = wrapException $ rawPerform writer doc fileInfo progress

--- a/opencascade-hs/src/OpenCascade/STEPControl/Writer.hs
+++ b/opencascade-hs/src/OpenCascade/STEPControl/Writer.hs
@@ -16,6 +16,7 @@ import Data.Acquire
 import OpenCascade.Internal.Bool (boolToCBool)
 import qualified OpenCascade.IFSelect.ReturnStatus as IFSelect.ReturnStatus
 import OpenCascade.STEPControl.StepModelType (StepModelType)
+import OpenCascade.Internal.Exception (wrapException)
 import Data.Coerce (coerce)
 
 foreign import capi unsafe "hs_STEPControl_Writer.h hs_new_STEPControl_Writer" rawNew :: IO (Ptr Writer)
@@ -30,12 +31,24 @@ setTolerance = coerce rawSetTolerance
 
 foreign import capi unsafe "hs_STEPControl_Writer.h hs_STEPControl_Writer_unsetTolerance" unsetTolerance :: Ptr Writer -> IO ()
 
-foreign import capi unsafe "hs_STEPControl_Writer.h hs_STEPControl_Writer_transfer" rawTransfer :: Ptr Writer -> Ptr TopoDS.Shape -> CInt -> CBool -> IO CInt
+foreign import capi unsafe "hs_STEPControl_Writer.h hs_STEPControl_Writer_transfer" rawTransfer
+    :: Ptr Writer
+    -> Ptr TopoDS.Shape
+    -> CInt
+    -> CBool
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO CInt
 
 transfer :: Ptr Writer -> Ptr TopoDS.Shape -> StepModelType -> Bool -> IO IFSelect.ReturnStatus.ReturnStatus
-transfer writer shape mode compgraph = toEnum . fromIntegral <$> rawTransfer writer shape (fromIntegral . fromEnum $ mode) (boolToCBool compgraph)
+transfer writer shape mode compgraph = toEnum . fromIntegral <$> wrapException (rawTransfer writer shape (fromIntegral . fromEnum $ mode) (boolToCBool compgraph))
 
-foreign import capi unsafe "hs_STEPControl_Writer.h hs_STEPControl_Writer_write" rawWrite :: Ptr Writer -> CString -> IO CInt
+foreign import capi unsafe "hs_STEPControl_Writer.h hs_STEPControl_Writer_write" rawWrite
+    :: Ptr Writer
+    -> CString
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO CInt
 
 write :: Ptr Writer -> String -> IO IFSelect.ReturnStatus.ReturnStatus
-write writer filename = toEnum . fromIntegral <$> withCString filename (rawWrite writer)
+write writer filename = toEnum . fromIntegral <$> withCString filename (wrapException . rawWrite writer)

--- a/opencascade-hs/src/OpenCascade/ShapeConstruct/Curve.hs
+++ b/opencascade-hs/src/OpenCascade/ShapeConstruct/Curve.hs
@@ -10,8 +10,9 @@ import OpenCascade.ShapeConstruct.Internal.Destructors (deleteCurve)
 import qualified OpenCascade.Geom.Types as Geom
 import OpenCascade.Geom.Internal.Destructors (deleteHandleBSplineCurve)
 import OpenCascade.Handle (Handle)
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.Ptr
-import Foreign.C (CDouble (..))
+import Foreign.C (CDouble (..), CInt)
 import Data.Acquire (Acquire, mkAcquire)
 import Data.Coerce (coerce)
 
@@ -20,9 +21,17 @@ foreign import capi unsafe "hs_ShapeConstruct_Curve.h hs_new_ShapeConstruct_Curv
 new :: Acquire (Ptr Curve)
 new = mkAcquire rawNew deleteCurve
 
-foreign import capi unsafe "hs_ShapeConstruct_Curve.h hs_ShapeConstruct_Curve_convertToBSpline" rawConvertToBSpline :: Ptr Curve -> Ptr (Handle Geom.Curve) -> CDouble -> CDouble -> CDouble -> IO (Ptr (Handle Geom.BSplineCurve))
+foreign import capi unsafe "hs_ShapeConstruct_Curve.h hs_ShapeConstruct_Curve_convertToBSpline" rawConvertToBSpline
+    :: Ptr Curve
+    -> Ptr (Handle Geom.Curve)
+    -> CDouble
+    -> CDouble
+    -> CDouble
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr (Handle Geom.BSplineCurve))
 
 convertToBSpline :: Ptr Curve -> Ptr (Handle Geom.Curve) -> Double -> Double -> Double -> Acquire (Ptr (Handle Geom.BSplineCurve))
-convertToBSpline shapeConstruct handleCurve firstParam lastParam precision = 
-    mkAcquire (rawConvertToBSpline shapeConstruct handleCurve (coerce firstParam) (coerce lastParam) (coerce precision)) deleteHandleBSplineCurve
+convertToBSpline shapeConstruct handleCurve firstParam lastParam precision =
+    mkAcquire (wrapException $ rawConvertToBSpline shapeConstruct handleCurve (coerce firstParam) (coerce lastParam) (coerce precision)) deleteHandleBSplineCurve
 

--- a/opencascade-hs/src/OpenCascade/ShapeExtend/WireData.hs
+++ b/opencascade-hs/src/OpenCascade/ShapeExtend/WireData.hs
@@ -14,26 +14,48 @@ import qualified OpenCascade.TopoDS as TopoDS
 import OpenCascade.TopoDS.Internal.Destructors (deleteShape)
 import OpenCascade.Internal.Bool (boolToCBool)
 import OpenCascade.Inheritance (upcast)
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.Ptr (Ptr)
-import Foreign.C (CBool (..))
+import Foreign.C (CBool (..), CInt)
 import Data.Acquire (Acquire, mkAcquire)
 
-foreign import capi unsafe "hs_ShapeExtend_WireData.h hs_new_ShapeExtend_WireData_fromWireChainedAndManifold" rawFromWireChainedAndManifold :: Ptr TopoDS.Wire -> CBool -> CBool -> IO (Ptr WireData)
+foreign import capi unsafe "hs_ShapeExtend_WireData.h hs_new_ShapeExtend_WireData_fromWireChainedAndManifold" rawFromWireChainedAndManifold
+    :: Ptr TopoDS.Wire
+    -> CBool
+    -> CBool
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr WireData)
 
 fromWireChainedAndManifold :: Ptr TopoDS.Wire -> Bool -> Bool -> Acquire (Ptr WireData)
-fromWireChainedAndManifold theWire chained manifold = 
-    mkAcquire (rawFromWireChainedAndManifold theWire (boolToCBool chained) (boolToCBool manifold)) (deleteWireData)
+fromWireChainedAndManifold theWire chained manifold =
+    mkAcquire (wrapException $ rawFromWireChainedAndManifold theWire (boolToCBool chained) (boolToCBool manifold)) (deleteWireData)
 
-foreign import capi unsafe "hs_ShapeExtend_WireData.h hs_ShapeExtend_WireData_reverse" reverse :: Ptr WireData -> IO ()
+foreign import capi unsafe "hs_ShapeExtend_WireData.h hs_ShapeExtend_WireData_reverse" rawReverse
+    :: Ptr WireData
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
+
+reverse :: Ptr WireData -> IO ()
+reverse wireData = wrapException $ rawReverse wireData
 
 
-foreign import capi unsafe "hs_ShapeExtend_WireData.h hs_ShapeExtend_WireData_wire" rawWire :: Ptr WireData -> IO (Ptr TopoDS.Wire)
+foreign import capi unsafe "hs_ShapeExtend_WireData.h hs_ShapeExtend_WireData_wire" rawWire
+    :: Ptr WireData
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Wire)
 
 wire :: Ptr WireData -> Acquire (Ptr TopoDS.Wire)
-wire wireData = mkAcquire (rawWire wireData) (deleteShape . upcast)
+wire wireData = mkAcquire (wrapException $ rawWire wireData) (deleteShape . upcast)
 
 
-foreign import capi unsafe "hs_ShapeExtend_WireData.h hs_ShapeExtend_WireData_wireAPIMake" rawWireAPIMake :: Ptr WireData -> IO (Ptr TopoDS.Wire)
+foreign import capi unsafe "hs_ShapeExtend_WireData.h hs_ShapeExtend_WireData_wireAPIMake" rawWireAPIMake
+    :: Ptr WireData
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Wire)
 
 wireAPIMake :: Ptr WireData -> Acquire (Ptr TopoDS.Wire)
-wireAPIMake wireData = mkAcquire (rawWireAPIMake wireData) (deleteShape . upcast)
+wireAPIMake wireData = mkAcquire (wrapException $ rawWireAPIMake wireData) (deleteShape . upcast)

--- a/opencascade-hs/src/OpenCascade/ShapeFix/Solid.hs
+++ b/opencascade-hs/src/OpenCascade/ShapeFix/Solid.hs
@@ -20,6 +20,7 @@ import Foreign.C (CInt (..), CBool (..))
 import OpenCascade.Internal.Bool (cBoolToBool)
 import OpenCascade.ShapeExtend.Status (Status)
 import OpenCascade.Inheritance (upcast)
+import OpenCascade.Internal.Exception (wrapException)
 
 
 foreign import capi unsafe "hs_ShapeFix_Solid.h hs_new_ShapeFix_Solid" rawNew :: IO (Ptr Solid)
@@ -27,25 +28,43 @@ foreign import capi unsafe "hs_ShapeFix_Solid.h hs_new_ShapeFix_Solid" rawNew ::
 new :: Acquire (Ptr Solid)
 new = mkAcquire rawNew deleteSolid
 
-foreign import capi unsafe "hs_ShapeFix_Solid.h hs_new_ShapeFix_Solid_fromSolid" rawFromSolid :: Ptr TopoDS.Solid -> IO (Ptr Solid)
+foreign import capi unsafe "hs_ShapeFix_Solid.h hs_new_ShapeFix_Solid_fromSolid" rawFromSolid
+    :: Ptr TopoDS.Solid
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr Solid)
 
 fromSolid :: Ptr TopoDS.Solid -> Acquire (Ptr Solid)
-fromSolid s = mkAcquire (rawFromSolid s) deleteSolid
+fromSolid s = mkAcquire (wrapException $ rawFromSolid s) deleteSolid
 
-foreign import capi unsafe "hs_ShapeFix_Solid.h hs_ShapeFix_Solid_perform" rawPerform :: Ptr Solid -> Ptr Message.ProgressRange -> IO (CBool)
+foreign import capi unsafe "hs_ShapeFix_Solid.h hs_ShapeFix_Solid_perform" rawPerform
+    :: Ptr Solid
+    -> Ptr Message.ProgressRange
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (CBool)
 
 perform :: Ptr Solid -> Ptr Message.ProgressRange-> IO Bool
-perform = (fmap cBoolToBool .) . rawPerform
+perform s progress = cBoolToBool <$> wrapException (rawPerform s progress)
 
-foreign import capi unsafe "hs_ShapeFix_Solid.h hs_ShapeFix_Solid_solid" rawSolid :: Ptr Solid -> IO (Ptr TopoDS.Shape)
+foreign import capi unsafe "hs_ShapeFix_Solid.h hs_ShapeFix_Solid_solid" rawSolid
+    :: Ptr Solid
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Shape)
 
 solid :: Ptr Solid -> Acquire (Ptr TopoDS.Shape)
-solid s = mkAcquire (rawSolid s) deleteShape
+solid s = mkAcquire (wrapException $ rawSolid s) deleteShape
 
-foreign import capi unsafe "hs_ShapeFix_Solid.h hs_ShapeFix_Solid_solidFromShell" rawSolidFromShell :: Ptr Solid -> Ptr TopoDS.Shell -> IO (Ptr TopoDS.Solid)
+foreign import capi unsafe "hs_ShapeFix_Solid.h hs_ShapeFix_Solid_solidFromShell" rawSolidFromShell
+    :: Ptr Solid
+    -> Ptr TopoDS.Shell
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Solid)
 
 solidFromShell :: Ptr Solid -> Ptr TopoDS.Shell -> Acquire (Ptr TopoDS.Solid)
-solidFromShell s shell = mkAcquire (rawSolidFromShell s shell) (deleteShape . upcast)
+solidFromShell s shell = mkAcquire (wrapException $ rawSolidFromShell s shell) (deleteShape . upcast)
 
 foreign import capi unsafe "hs_ShapeFix_Solid.h hs_ShapeFix_Solid_status" rawStatus :: Ptr Solid -> CInt -> IO CBool
 

--- a/opencascade-hs/src/OpenCascade/Standard/Failure.hs
+++ b/opencascade-hs/src/OpenCascade/Standard/Failure.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE CApiFFI #-}
+module OpenCascade.Standard.Failure
+( Failure
+, getStackString 
+) where
+
+import OpenCascade.Standard.Types (Failure)
+import Foreign.C (CString)
+import Foreign.Ptr (Ptr)
+
+foreign import capi unsafe "hs_Standard_Failure.h hs_Standard_Failure_GetStackString" getStackString :: Ptr Failure -> IO CString

--- a/opencascade-hs/src/OpenCascade/Standard/Failure.hs
+++ b/opencascade-hs/src/OpenCascade/Standard/Failure.hs
@@ -1,11 +1,14 @@
 {-# LANGUAGE CApiFFI #-}
 module OpenCascade.Standard.Failure
 ( Failure
+, getMessageString
 , getStackString 
 ) where
 
 import OpenCascade.Standard.Types (Failure)
 import Foreign.C (CString)
 import Foreign.Ptr (Ptr)
+
+foreign import capi unsafe "hs_Standard_Failure.h hs_Standard_Failure_GetMessageString" getMessageString :: Ptr Failure -> IO CString
 
 foreign import capi unsafe "hs_Standard_Failure.h hs_Standard_Failure_GetStackString" getStackString :: Ptr Failure -> IO CString

--- a/opencascade-hs/src/OpenCascade/Standard/Internal/Destructors.hs
+++ b/opencascade-hs/src/OpenCascade/Standard/Internal/Destructors.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE CApiFFI #-}
+module OpenCascade.Standard.Internal.Destructors 
+( deleteFailure
+)where
+
+import OpenCascade.Standard.Types (Failure)
+import Foreign.Ptr (Ptr)
+
+foreign import capi unsafe "hs_Standard_Failure.h hs_delete_Standard_Failure" deleteFailure :: Ptr Failure -> IO ()

--- a/opencascade-hs/src/OpenCascade/Standard/Types.hs
+++ b/opencascade-hs/src/OpenCascade/Standard/Types.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+module OpenCascade.Standard.Types 
+(Failure
+) where
+
+import OpenCascade.Std.Types (Exception)
+import OpenCascade.Inheritance (SubTypeOf)
+
+data Failure
+
+instance SubTypeOf Exception Failure

--- a/opencascade-hs/src/OpenCascade/Std/Exception.hs
+++ b/opencascade-hs/src/OpenCascade/Std/Exception.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE CApiFFI #-}
+module OpenCascade.Std.Exception
+( Exception
+, what
+) where
+
+import OpenCascade.Std.Types (Exception)
+import Foreign.C (CString)
+import Foreign.Ptr (Ptr)
+
+foreign import capi unsafe "hs_Exception.h hs_std_exception_what" what :: Ptr Exception -> IO CString

--- a/opencascade-hs/src/OpenCascade/Std/Internal/Destructors.hs
+++ b/opencascade-hs/src/OpenCascade/Std/Internal/Destructors.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE CApiFFI #-}
+module OpenCascade.Std.Internal.Destructors 
+( deleteException
+) where
+
+import OpenCascade.Std.Types (Exception)
+import Foreign.Ptr (Ptr)
+
+foreign import capi unsafe "hs_Exception.h hs_delete_std_exception" deleteException :: Ptr Exception -> IO ()

--- a/opencascade-hs/src/OpenCascade/Std/RuntimeError.hs
+++ b/opencascade-hs/src/OpenCascade/Std/RuntimeError.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE CApiFFI #-}
+module OpenCascade.Std.RuntimeError 
+( RuntimeError
+, new
+) where 
+
+import OpenCascade.Std.Internal.Destructors (deleteException)
+import OpenCascade.Std.Types (RuntimeError)
+import Data.Acquire (Acquire, mkAcquire)
+import Foreign.Ptr (Ptr)
+import Foreign.C.String (CString, withCString)
+import OpenCascade.Inheritance (upcast)
+
+foreign import capi unsafe "hs_Exception.h hs_new_runtime_error" rawNew :: CString -> IO (Ptr RuntimeError)
+
+new :: String -> Acquire (Ptr RuntimeError)
+new s = mkAcquire (withCString s rawNew) (deleteException . upcast)

--- a/opencascade-hs/src/OpenCascade/Std/Types.hs
+++ b/opencascade-hs/src/OpenCascade/Std/Types.hs
@@ -1,0 +1,5 @@
+module OpenCascade.Std.Types
+( Exception
+) where
+
+data Exception

--- a/opencascade-hs/src/OpenCascade/Std/Types.hs
+++ b/opencascade-hs/src/OpenCascade/Std/Types.hs
@@ -1,5 +1,12 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
 module OpenCascade.Std.Types
 ( Exception
+, RuntimeError
 ) where
 
+import OpenCascade.Inheritance
+
 data Exception
+data RuntimeError
+
+instance SubTypeOf Exception RuntimeError

--- a/opencascade-hs/src/OpenCascade/StlAPI/Reader.hs
+++ b/opencascade-hs/src/OpenCascade/StlAPI/Reader.hs
@@ -13,13 +13,20 @@ import Foreign.C
 import Foreign.Ptr
 import Data.Acquire
 import OpenCascade.Internal.Bool (cBoolToBool)
+import OpenCascade.Internal.Exception (wrapException)
 
 foreign import capi unsafe "hs_StlAPI_Reader.h hs_new_StlAPI_Reader" rawNew :: IO (Ptr Reader)
 
 new :: Acquire (Ptr Reader)
 new = mkAcquire rawNew deleteReader
 
-foreign import capi unsafe "hs_StlAPI_Reader.h hs_StlAPI_Reader_read" rawRead :: Ptr Reader -> Ptr TopoDS.Shape -> CString -> IO (CBool)
+foreign import capi unsafe "hs_StlAPI_Reader.h hs_StlAPI_Reader_read" rawRead
+    :: Ptr Reader
+    -> Ptr TopoDS.Shape
+    -> CString
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (CBool)
 
 read :: Ptr Reader -> Ptr TopoDS.Shape -> String -> IO (Bool)
-read reader shape filename = cBoolToBool <$> withCString filename (rawRead reader shape)
+read reader shape filename = cBoolToBool <$> withCString filename (wrapException . rawRead reader shape)

--- a/opencascade-hs/src/OpenCascade/StlAPI/Writer.hs
+++ b/opencascade-hs/src/OpenCascade/StlAPI/Writer.hs
@@ -13,6 +13,7 @@ import Foreign.C
 import Foreign.Ptr
 import Data.Acquire
 import OpenCascade.Internal.Bool (boolToCBool, cBoolToBool)
+import OpenCascade.Internal.Exception (wrapException)
 
 foreign import capi unsafe "hs_StlAPI_Writer.h hs_new_StlAPI_Writer" rawNew :: IO (Ptr Writer)
 
@@ -25,7 +26,13 @@ setAsciiMode :: Ptr Writer -> Bool -> IO ()
 setAsciiMode writer mode = rawSetAsciiMode writer (boolToCBool mode)
 
 
-foreign import capi unsafe "hs_StlAPI_Writer.h hs_StlAPI_Writer_write" rawWrite :: Ptr Writer -> Ptr TopoDS.Shape -> CString -> IO (CBool)
+foreign import capi unsafe "hs_StlAPI_Writer.h hs_StlAPI_Writer_write" rawWrite
+    :: Ptr Writer
+    -> Ptr TopoDS.Shape
+    -> CString
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (CBool)
 
 write :: Ptr Writer -> Ptr TopoDS.Shape -> String -> IO (Bool)
-write writer shape filename = cBoolToBool <$> withCString filename (rawWrite writer shape)
+write writer shape filename = cBoolToBool <$> withCString filename (wrapException . rawWrite writer shape)

--- a/opencascade-hs/src/OpenCascade/TDocStd/Document.hs
+++ b/opencascade-hs/src/OpenCascade/TDocStd/Document.hs
@@ -10,16 +10,26 @@ import OpenCascade.TDocStd.Internal.Destructors (deleteDocumentHandle)
 import OpenCascade.TDF.Types (Label)
 import OpenCascade.TDF.Internal.Destructors (deleteLabel)
 import OpenCascade.Handle (Handle)
+import OpenCascade.Internal.Exception (wrapException)
 import Data.Acquire (Acquire, mkAcquire)
+import Foreign.C (CInt)
 import Foreign.Ptr (Ptr)
 import Foreign.C.String (CString, withCString)
 
-foreign import capi unsafe "hs_TDocStd_Document.h hs_new_TDocStd_Document" rawNew :: CString -> IO (Ptr (Handle Document))
+foreign import capi unsafe "hs_TDocStd_Document.h hs_new_TDocStd_Document" rawNew
+    :: CString
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr (Handle Document))
 
 fromStorageFormat :: String -> Acquire (Ptr (Handle Document))
-fromStorageFormat fmt = mkAcquire (withCString fmt rawNew) deleteDocumentHandle
+fromStorageFormat fmt = mkAcquire (withCString fmt $ \s -> wrapException $ rawNew s) deleteDocumentHandle
 
-foreign import capi unsafe "hs_TDocStd_Document.h hs_TDocStd_Document_main" rawMain :: Ptr (Handle Document) -> IO (Ptr Label)
+foreign import capi unsafe "hs_TDocStd_Document.h hs_TDocStd_Document_main" rawMain
+    :: Ptr (Handle Document)
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr Label)
 
 main :: Ptr (Handle Document) -> Acquire (Ptr Label)
-main doc = mkAcquire (rawMain doc) deleteLabel  
+main doc = mkAcquire (wrapException $ rawMain doc) deleteLabel

--- a/opencascade-hs/src/OpenCascade/TopExp/Explorer.hs
+++ b/opencascade-hs/src/OpenCascade/TopExp/Explorer.hs
@@ -15,17 +15,37 @@ import Data.Acquire
 import Foreign.Ptr
 import Foreign.C
 import OpenCascade.Internal.Bool (cBoolToBool)
+import OpenCascade.Internal.Exception (wrapException)
 
-foreign import capi unsafe "hs_TopExp_Explorer.h hs_new_TopExp_Explorer" rawNew :: Ptr TopoDS.Shape -> CInt -> IO (Ptr Explorer)
+foreign import capi unsafe "hs_TopExp_Explorer.h hs_new_TopExp_Explorer" rawNew
+    :: Ptr TopoDS.Shape
+    -> CInt
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr Explorer)
 
 new :: Ptr TopoDS.Shape -> TopAbs.ShapeEnum -> Acquire (Ptr Explorer)
-new shape theType = mkAcquire (rawNew shape (fromIntegral . fromEnum $ theType)) deleteExplorer
+new shape theType = mkAcquire (wrapException $ rawNew shape (fromIntegral . fromEnum $ theType)) deleteExplorer
 
 foreign import capi unsafe "hs_TopExp_Explorer.h hs_TopExp_Explorer_more" rawMore :: Ptr Explorer -> IO (CBool)
 
 more :: Ptr Explorer -> IO Bool
-more = fmap (cBoolToBool) . rawMore 
+more = fmap (cBoolToBool) . rawMore
 
-foreign import capi unsafe "hs_TopExp_Explorer.h hs_TopExp_Explorer_next" next :: Ptr Explorer -> IO ()
+foreign import capi unsafe "hs_TopExp_Explorer.h hs_TopExp_Explorer_next" rawNext
+    :: Ptr Explorer
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO ()
 
-foreign import capi unsafe "hs_TopExp_Explorer.h hs_TopExp_Explorer_value" value :: Ptr Explorer -> IO (Ptr TopoDS.Shape)
+next :: Ptr Explorer -> IO ()
+next explorer = wrapException $ rawNext explorer
+
+foreign import capi unsafe "hs_TopExp_Explorer.h hs_TopExp_Explorer_value" rawValue
+    :: Ptr Explorer
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Shape)
+
+value :: Ptr Explorer -> IO (Ptr TopoDS.Shape)
+value explorer = wrapException $ rawValue explorer

--- a/opencascade-hs/src/OpenCascade/TopLoc/Location.hs
+++ b/opencascade-hs/src/OpenCascade/TopLoc/Location.hs
@@ -20,9 +20,10 @@ module OpenCascade.TopLoc.Location
 import OpenCascade.TopLoc.Types
 import OpenCascade.TopLoc.Internal.Destructors
 import OpenCascade.GP.Internal.Destructors (deleteTrsf)
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.C
 import Foreign.Ptr
-import Data.Acquire 
+import Data.Acquire
 import qualified OpenCascade.GP as GP
 
 -- new 
@@ -55,47 +56,53 @@ firstPower l = fromIntegral <$> rawFirstPower l
 
 -- nextLocation
 
-foreign import capi unsafe "hs_TopLoc_Location.h hs_TopLoc_Location_NextLocation" rawNextLocation :: Ptr Location -> IO (Ptr Location)
+foreign import capi unsafe "hs_TopLoc_Location.h hs_TopLoc_Location_NextLocation" rawNextLocation
+    :: Ptr Location -> Ptr CInt -> Ptr (Ptr ()) -> IO (Ptr Location)
 
 nextLocation :: Ptr Location -> Acquire (Ptr Location)
-nextLocation l = mkAcquire (rawNextLocation l) deleteLocation
+nextLocation l = mkAcquire (wrapException $ rawNextLocation l) deleteLocation
 
 -- inverted
 
-foreign import capi unsafe "hs_TopLoc_Location.h hs_TopLoc_Location_Inverted" rawInverted :: Ptr Location -> IO (Ptr Location)
+foreign import capi unsafe "hs_TopLoc_Location.h hs_TopLoc_Location_Inverted" rawInverted
+    :: Ptr Location -> Ptr CInt -> Ptr (Ptr ()) -> IO (Ptr Location)
 
 inverted :: Ptr Location -> Acquire (Ptr Location)
-inverted l = mkAcquire (rawInverted l) deleteLocation
+inverted l = mkAcquire (wrapException $ rawInverted l) deleteLocation
 
 -- multiplied
 
-foreign import capi unsafe "hs_TopLoc_Location.h hs_TopLoc_Location_Multiplied" rawMultiplied :: Ptr Location -> Ptr Location -> IO (Ptr Location)
+foreign import capi unsafe "hs_TopLoc_Location.h hs_TopLoc_Location_Multiplied" rawMultiplied
+    :: Ptr Location -> Ptr Location -> Ptr CInt -> Ptr (Ptr ()) -> IO (Ptr Location)
 
 multiplied :: Ptr Location -> Ptr Location -> Acquire (Ptr Location)
-multiplied a b = mkAcquire (rawMultiplied a b) deleteLocation
+multiplied a b = mkAcquire (wrapException $ rawMultiplied a b) deleteLocation
 
 
 -- divided
 
-foreign import capi unsafe "hs_TopLoc_Location.h hs_TopLoc_Location_Divided" rawDivided :: Ptr Location -> Ptr Location -> IO (Ptr Location)
+foreign import capi unsafe "hs_TopLoc_Location.h hs_TopLoc_Location_Divided" rawDivided
+    :: Ptr Location -> Ptr Location -> Ptr CInt -> Ptr (Ptr ()) -> IO (Ptr Location)
 
 divided :: Ptr Location -> Ptr Location -> Acquire (Ptr Location)
-divided a b = mkAcquire (rawDivided a b) deleteLocation
+divided a b = mkAcquire (wrapException $ rawDivided a b) deleteLocation
 
 
 -- predivided
 
-foreign import capi unsafe "hs_TopLoc_Location.h hs_TopLoc_Location_Predivided" rawPredivided :: Ptr Location -> Ptr Location -> IO (Ptr Location)
+foreign import capi unsafe "hs_TopLoc_Location.h hs_TopLoc_Location_Predivided" rawPredivided
+    :: Ptr Location -> Ptr Location -> Ptr CInt -> Ptr (Ptr ()) -> IO (Ptr Location)
 
 predivided :: Ptr Location -> Ptr Location -> Acquire (Ptr Location)
-predivided a b = mkAcquire (rawPredivided a b) deleteLocation
+predivided a b = mkAcquire (wrapException $ rawPredivided a b) deleteLocation
 
 -- powered
 
-foreign import capi unsafe "hs_TopLoc_Location.h hs_TopLoc_Location_Powered" rawPowered :: Ptr Location -> CInt -> IO (Ptr Location)
+foreign import capi unsafe "hs_TopLoc_Location.h hs_TopLoc_Location_Powered" rawPowered
+    :: Ptr Location -> CInt -> Ptr CInt -> Ptr (Ptr ()) -> IO (Ptr Location)
 
 powered :: Ptr Location -> Int -> Acquire (Ptr Location)
-powered l p = mkAcquire (rawPowered l (fromIntegral p)) deleteLocation
+powered l p = mkAcquire (wrapException $ rawPowered l (fromIntegral p)) deleteLocation
 
 -- isEqual
 

--- a/opencascade-hs/src/OpenCascade/TopTools/ShapeMapHasher.hs
+++ b/opencascade-hs/src/OpenCascade/TopTools/ShapeMapHasher.hs
@@ -8,13 +8,23 @@ import qualified OpenCascade.TopoDS.Types as TopoDS
 import Foreign.Ptr (Ptr)
 import Foreign.C (CInt (..), CBool (..))
 import OpenCascade.Internal.Bool (cBoolToBool)
+import OpenCascade.Internal.Exception (wrapException)
 
-foreign import capi unsafe "hs_TopTools_ShapeMapHasher.h hs_TopTools_ShapeMapHasher_hash" rawHash :: Ptr TopoDS.Shape -> IO (CInt)
+foreign import capi unsafe "hs_TopTools_ShapeMapHasher.h hs_TopTools_ShapeMapHasher_hash" rawHash 
+    :: Ptr TopoDS.Shape 
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (CInt)
 
 hash :: Ptr TopoDS.Shape -> IO Int
-hash s = fromIntegral <$> rawHash s
+hash s = fromIntegral <$> wrapException (rawHash s)
 
-foreign import capi unsafe "hs_TopTools_ShapeMapHasher.h hs_TopTools_ShapeMapHasher_isEqual" rawIsEqual :: Ptr TopoDS.Shape -> Ptr TopoDS.Shape -> IO (CBool)
+foreign import capi unsafe "hs_TopTools_ShapeMapHasher.h hs_TopTools_ShapeMapHasher_isEqual" rawIsEqual 
+    :: Ptr TopoDS.Shape 
+    -> Ptr TopoDS.Shape 
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (CBool)
 
 isEqual :: Ptr TopoDS.Shape -> Ptr TopoDS.Shape -> IO Bool
-isEqual a b = cBoolToBool <$> rawIsEqual a b
+isEqual a b = cBoolToBool <$> wrapException (rawIsEqual a b)

--- a/opencascade-hs/src/OpenCascade/TopoDS/Builder.hs
+++ b/opencascade-hs/src/OpenCascade/TopoDS/Builder.hs
@@ -11,8 +11,10 @@ module OpenCascade.TopoDS.Builder
 , remove
 ) where
 
-import OpenCascade.TopoDS.Types 
+import OpenCascade.TopoDS.Types
 import OpenCascade.TopoDS.Internal.Destructors (deleteBuilder)
+import OpenCascade.Internal.Exception (wrapException)
+import Foreign.C (CInt)
 import Foreign.Ptr (Ptr)
 import Data.Acquire (Acquire, mkAcquire)
 
@@ -21,16 +23,44 @@ foreign import capi unsafe "hs_TopoDS_Builder.h hs_new_TopoDS_Builder" rawNew ::
 new :: Acquire (Ptr Builder)
 new = mkAcquire rawNew deleteBuilder
 
-foreign import capi unsafe "hs_TopoDS_Builder.h hs_TopoDS_Builder_makeWire" makeWire :: Ptr Builder -> Ptr Wire -> IO ()
+foreign import capi unsafe "hs_TopoDS_Builder.h hs_TopoDS_Builder_makeWire" rawMakeWire
+    :: Ptr Builder -> Ptr Wire -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
-foreign import capi unsafe "hs_TopoDS_Builder.h hs_TopoDS_Builder_makeShell" makeShell :: Ptr Builder -> Ptr Shell -> IO ()
+makeWire :: Ptr Builder -> Ptr Wire -> IO ()
+makeWire builder wire = wrapException $ rawMakeWire builder wire
 
-foreign import capi unsafe "hs_TopoDS_Builder.h hs_TopoDS_Builder_makeSolid" makeSolid :: Ptr Builder -> Ptr Solid -> IO ()
+foreign import capi unsafe "hs_TopoDS_Builder.h hs_TopoDS_Builder_makeShell" rawMakeShell
+    :: Ptr Builder -> Ptr Shell -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
-foreign import capi unsafe "hs_TopoDS_Builder.h hs_TopoDS_Builder_makeCompSolid" makeCompSolid :: Ptr Builder -> Ptr CompSolid -> IO ()
+makeShell :: Ptr Builder -> Ptr Shell -> IO ()
+makeShell builder shell = wrapException $ rawMakeShell builder shell
 
-foreign import capi unsafe "hs_TopoDS_Builder.h hs_TopoDS_Builder_makeCompound" makeCompound :: Ptr Builder -> Ptr Compound -> IO ()
+foreign import capi unsafe "hs_TopoDS_Builder.h hs_TopoDS_Builder_makeSolid" rawMakeSolid
+    :: Ptr Builder -> Ptr Solid -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
-foreign import capi unsafe "hs_TopoDS_Builder.h hs_TopoDS_Builder_add" add :: Ptr Builder -> Ptr Shape -> Ptr Shape -> IO ()
+makeSolid :: Ptr Builder -> Ptr Solid -> IO ()
+makeSolid builder solid = wrapException $ rawMakeSolid builder solid
 
-foreign import capi unsafe "hs_TopoDS_Builder.h hs_TopoDS_Builder_remove" remove :: Ptr Builder -> Ptr Shape -> Ptr Shape -> IO ()
+foreign import capi unsafe "hs_TopoDS_Builder.h hs_TopoDS_Builder_makeCompSolid" rawMakeCompSolid
+    :: Ptr Builder -> Ptr CompSolid -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
+
+makeCompSolid :: Ptr Builder -> Ptr CompSolid -> IO ()
+makeCompSolid builder solid = wrapException $ rawMakeCompSolid builder solid
+
+foreign import capi unsafe "hs_TopoDS_Builder.h hs_TopoDS_Builder_makeCompound" rawMakeCompound
+    :: Ptr Builder -> Ptr Compound -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
+
+makeCompound :: Ptr Builder -> Ptr Compound -> IO ()
+makeCompound builder compound = wrapException $ rawMakeCompound builder compound
+
+foreign import capi unsafe "hs_TopoDS_Builder.h hs_TopoDS_Builder_add" rawAdd
+    :: Ptr Builder -> Ptr Shape -> Ptr Shape -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
+
+add :: Ptr Builder -> Ptr Shape -> Ptr Shape -> IO ()
+add builder s c = wrapException $ rawAdd builder s c
+
+foreign import capi unsafe "hs_TopoDS_Builder.h hs_TopoDS_Builder_remove" rawRemove
+    :: Ptr Builder -> Ptr Shape -> Ptr Shape -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
+
+remove :: Ptr Builder -> Ptr Shape -> Ptr Shape -> IO ()
+remove builder s c = wrapException $ rawRemove builder s c

--- a/opencascade-hs/src/OpenCascade/TopoDS/Shape.hs
+++ b/opencascade-hs/src/OpenCascade/TopoDS/Shape.hs
@@ -47,9 +47,10 @@ import Prelude hiding (reverse)
 import OpenCascade.TopoDS.Types
 import OpenCascade.TopoDS.Internal.Destructors
 import OpenCascade.Internal.Bool
+import OpenCascade.Internal.Exception (wrapException)
 import Foreign.C
 import Foreign.Ptr
-import Data.Acquire 
+import Data.Acquire
 
 import qualified OpenCascade.TopLoc as TopLoc
 import qualified OpenCascade.TopLoc.Internal.Destructors as TopLoc.Destructors
@@ -68,267 +69,285 @@ foreign import capi unsafe "hs_TopoDS_Shape.h hs_new_TopoDS_Shape_copy" rawCopy 
 copy :: Ptr Shape -> Acquire (Ptr Shape)
 copy shape = mkAcquire (rawCopy shape)  deleteShape
 
--- isNull 
+-- isNull
 --
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_IsNull" rawIsNull :: Ptr Shape -> IO CBool
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_IsNull" rawIsNull :: Ptr Shape -> Ptr CInt -> Ptr (Ptr ()) -> IO CBool
 
 isNull :: Ptr Shape -> IO Bool
-isNull s = cBoolToBool <$> rawIsNull s
+isNull s = cBoolToBool <$> wrapException (rawIsNull s)
 
--- Nullify 
+-- Nullify
 --
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Nullify" nullify :: Ptr Shape -> IO ()
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Nullify" rawNullify :: Ptr Shape -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
--- location 
+nullify :: Ptr Shape -> IO ()
+nullify s = wrapException $ rawNullify s
+
+-- location
 --
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Location" rawLocation :: Ptr Shape -> IO (Ptr TopLoc.Location)
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Location" rawLocation :: Ptr Shape -> Ptr CInt -> Ptr (Ptr ()) -> IO (Ptr TopLoc.Location)
 
 location :: Ptr Shape -> Acquire (Ptr TopLoc.Location)
-location s = mkAcquire (rawLocation s) TopLoc.Destructors.deleteLocation  
+location s = mkAcquire (wrapException $ rawLocation s) TopLoc.Destructors.deleteLocation
 
--- setLocation 
+-- setLocation
 --
 
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_SetLocation" setLocation :: Ptr Shape -> Ptr TopLoc.Location -> IO ()
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_SetLocation" rawSetLocation :: Ptr Shape -> Ptr TopLoc.Location -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
+
+setLocation :: Ptr Shape -> Ptr TopLoc.Location -> IO ()
+setLocation s l = wrapException $ rawSetLocation s l
 
 -- located
 --
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Located" rawLocated :: Ptr Shape -> Ptr TopLoc.Location -> IO (Ptr Shape)
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Located" rawLocated :: Ptr Shape -> Ptr TopLoc.Location -> Ptr CInt -> Ptr (Ptr ()) -> IO (Ptr Shape)
 
 located :: Ptr Shape -> Ptr TopLoc.Location -> Acquire (Ptr Shape)
-located s l = mkAcquire (rawLocated s l) deleteShape
+located s l = mkAcquire (wrapException $ rawLocated s l) deleteShape
 
 
 -- orientation
 
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Orientation" rawOrientation :: Ptr Shape -> IO (CInt)
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Orientation" rawOrientation :: Ptr Shape -> Ptr CInt -> Ptr (Ptr ()) -> IO (CInt)
 
 orientation :: Ptr Shape -> IO TopAbs.Orientation
-orientation s = toEnum . fromIntegral <$> rawOrientation s
+orientation s = toEnum . fromIntegral <$> wrapException (rawOrientation s)
 
 -- setOrientation
 
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_SetOrientation" rawSetOrientation :: Ptr Shape -> CInt -> IO ()
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_SetOrientation" rawSetOrientation :: Ptr Shape -> CInt -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
 setOrientation :: Ptr Shape -> TopAbs.Orientation -> IO ()
-setOrientation s o = rawSetOrientation s (fromIntegral . fromEnum $ o) 
+setOrientation s o = wrapException $ rawSetOrientation s (fromIntegral . fromEnum $ o)
 
 
 -- oriented
 --
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Oriented" rawOriented :: Ptr Shape -> CInt -> IO (Ptr Shape)
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Oriented" rawOriented :: Ptr Shape -> CInt -> Ptr CInt -> Ptr (Ptr ()) -> IO (Ptr Shape)
 
 oriented :: Ptr Shape -> TopAbs.Orientation -> Acquire (Ptr Shape)
-oriented s o = mkAcquire (rawOriented s (fromIntegral . fromEnum $ o)) deleteShape
+oriented s o = mkAcquire (wrapException $ rawOriented s (fromIntegral . fromEnum $ o)) deleteShape
 
--- shapeType 
+-- shapeType
 --
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_ShapeType" rawShapeType :: Ptr Shape -> IO CInt
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_ShapeType" rawShapeType :: Ptr Shape -> Ptr CInt -> Ptr (Ptr ()) -> IO CInt
 
 shapeType :: Ptr Shape -> IO TopAbs.ShapeEnum
-shapeType s = toEnum . fromIntegral <$> rawShapeType s
+shapeType s = toEnum . fromIntegral <$> wrapException (rawShapeType s)
 
 -- free
 
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Free" rawFree :: Ptr Shape -> IO CBool
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Free" rawFree :: Ptr Shape -> Ptr CInt -> Ptr (Ptr ()) -> IO CBool
 
 free :: Ptr Shape -> IO Bool
-free s = cBoolToBool <$> rawFree s
+free s = cBoolToBool <$> wrapException (rawFree s)
 
---setFree 
+--setFree
 
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_SetFree" rawSetFree :: Ptr Shape -> CBool-> IO ()
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_SetFree" rawSetFree :: Ptr Shape -> CBool -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
 setFree :: Ptr Shape -> Bool -> IO ()
-setFree s b = rawSetFree s (boolToCBool b)
+setFree s b = wrapException $ rawSetFree s (boolToCBool b)
 
 -- locked
 
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Locked" rawLocked :: Ptr Shape -> IO CBool
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Locked" rawLocked :: Ptr Shape -> Ptr CInt -> Ptr (Ptr ()) -> IO CBool
 
 locked :: Ptr Shape -> IO Bool
-locked s = cBoolToBool <$> rawLocked s
+locked s = cBoolToBool <$> wrapException (rawLocked s)
 
---setLocked 
+--setLocked
 
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_SetLocked" rawSetLocked :: Ptr Shape -> CBool-> IO ()
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_SetLocked" rawSetLocked :: Ptr Shape -> CBool -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
 setLocked :: Ptr Shape -> Bool -> IO ()
-setLocked s b = rawSetLocked s (boolToCBool b)
+setLocked s b = wrapException $ rawSetLocked s (boolToCBool b)
 
 
 
 -- modified
 
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Modified" rawModified :: Ptr Shape -> IO CBool
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Modified" rawModified :: Ptr Shape -> Ptr CInt -> Ptr (Ptr ()) -> IO CBool
 
 modified :: Ptr Shape -> IO Bool
-modified s = cBoolToBool <$> rawModified s
+modified s = cBoolToBool <$> wrapException (rawModified s)
 
---setModified 
+--setModified
 
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_SetModified" rawSetModified :: Ptr Shape -> CBool-> IO ()
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_SetModified" rawSetModified :: Ptr Shape -> CBool -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
 setModified :: Ptr Shape -> Bool -> IO ()
-setModified s b = rawSetModified s (boolToCBool b)
+setModified s b = wrapException $ rawSetModified s (boolToCBool b)
 
 
 -- checked
 
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Checked" rawChecked :: Ptr Shape -> IO CBool
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Checked" rawChecked :: Ptr Shape -> Ptr CInt -> Ptr (Ptr ()) -> IO CBool
 
 checked :: Ptr Shape -> IO Bool
-checked s = cBoolToBool <$> rawChecked s
+checked s = cBoolToBool <$> wrapException (rawChecked s)
 
---setChecked 
+--setChecked
 
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_SetChecked" rawSetChecked :: Ptr Shape -> CBool-> IO ()
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_SetChecked" rawSetChecked :: Ptr Shape -> CBool -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
 setChecked :: Ptr Shape -> Bool -> IO ()
-setChecked s b = rawSetChecked s (boolToCBool b)
+setChecked s b = wrapException $ rawSetChecked s (boolToCBool b)
 
 -- orientable
 
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Orientable" rawOrientable :: Ptr Shape -> IO CBool
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Orientable" rawOrientable :: Ptr Shape -> Ptr CInt -> Ptr (Ptr ()) -> IO CBool
 
 orientable :: Ptr Shape -> IO Bool
-orientable s = cBoolToBool <$> rawOrientable s
+orientable s = cBoolToBool <$> wrapException (rawOrientable s)
 
---setOrientable 
+--setOrientable
 
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_SetOrientable" rawSetOrientable :: Ptr Shape -> CBool-> IO ()
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_SetOrientable" rawSetOrientable :: Ptr Shape -> CBool -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
 setOrientable :: Ptr Shape -> Bool -> IO ()
-setOrientable s b = rawSetOrientable s (boolToCBool b)
+setOrientable s b = wrapException $ rawSetOrientable s (boolToCBool b)
 
 -- closed
 
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Closed" rawClosed :: Ptr Shape -> IO CBool
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Closed" rawClosed :: Ptr Shape -> Ptr CInt -> Ptr (Ptr ()) -> IO CBool
 
 closed :: Ptr Shape -> IO Bool
-closed s = cBoolToBool <$> rawClosed s
+closed s = cBoolToBool <$> wrapException (rawClosed s)
 
---setClosed 
+--setClosed
 
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_SetClosed" rawSetClosed :: Ptr Shape -> CBool-> IO ()
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_SetClosed" rawSetClosed :: Ptr Shape -> CBool -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
 setClosed :: Ptr Shape -> Bool -> IO ()
-setClosed s b = rawSetClosed s (boolToCBool b)
+setClosed s b = wrapException $ rawSetClosed s (boolToCBool b)
 
 
 -- infinite
 
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Infinite" rawInfinite :: Ptr Shape -> IO CBool
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Infinite" rawInfinite :: Ptr Shape -> Ptr CInt -> Ptr (Ptr ()) -> IO CBool
 
 infinite :: Ptr Shape -> IO Bool
-infinite s = cBoolToBool <$> rawInfinite s
+infinite s = cBoolToBool <$> wrapException (rawInfinite s)
 
---setInfinite 
+--setInfinite
 
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_SetInfinite" rawSetInfinite :: Ptr Shape -> CBool-> IO ()
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_SetInfinite" rawSetInfinite :: Ptr Shape -> CBool -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
 setInfinite :: Ptr Shape -> Bool -> IO ()
-setInfinite s b = rawSetInfinite s (boolToCBool b)
+setInfinite s b = wrapException $ rawSetInfinite s (boolToCBool b)
 
 
 
 -- convex
 
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Convex" rawConvex :: Ptr Shape -> IO CBool
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Convex" rawConvex :: Ptr Shape -> Ptr CInt -> Ptr (Ptr ()) -> IO CBool
 
 convex :: Ptr Shape -> IO Bool
-convex s = cBoolToBool <$> rawConvex s
+convex s = cBoolToBool <$> wrapException (rawConvex s)
 
---setConvex 
+--setConvex
 
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_SetConvex" rawSetConvex :: Ptr Shape -> CBool-> IO ()
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_SetConvex" rawSetConvex :: Ptr Shape -> CBool -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
 
 setConvex :: Ptr Shape -> Bool -> IO ()
-setConvex s b = rawSetConvex s (boolToCBool b)
+setConvex s b = wrapException $ rawSetConvex s (boolToCBool b)
 
 
 -- move
 --
 
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Move" move :: Ptr Shape -> Ptr TopLoc.Location -> IO ()
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Move" rawMove :: Ptr Shape -> Ptr TopLoc.Location -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
+
+move :: Ptr Shape -> Ptr TopLoc.Location -> IO ()
+move s l = wrapException $ rawMove s l
 
 -- moved
 --
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Moved" rawMoved :: Ptr Shape -> Ptr TopLoc.Location -> IO (Ptr Shape)
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Moved" rawMoved :: Ptr Shape -> Ptr TopLoc.Location -> Ptr CInt -> Ptr (Ptr ()) -> IO (Ptr Shape)
 
 moved :: Ptr Shape -> Ptr TopLoc.Location -> Acquire (Ptr Shape)
-moved s l = mkAcquire (rawMoved s l) deleteShape
+moved s l = mkAcquire (wrapException $ rawMoved s l) deleteShape
 
 -- nbChildren
 
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_NbChildren" rawNbChildren :: Ptr Shape -> IO (CInt)
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_NbChildren" rawNbChildren :: Ptr Shape -> Ptr CInt -> Ptr (Ptr ()) -> IO (CInt)
 
 nbChildren :: Ptr Shape -> IO Int
-nbChildren s = fromIntegral <$> rawNbChildren s
+nbChildren s = fromIntegral <$> wrapException (rawNbChildren s)
 
 -- reverse
 --
 
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Reverse" reverse :: Ptr Shape -> IO ()
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Reverse" rawReverse :: Ptr Shape -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
+
+reverse :: Ptr Shape -> IO ()
+reverse s = wrapException $ rawReverse s
 
 -- reversed
 --
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Reversed" rawReversed :: Ptr Shape -> IO (Ptr Shape)
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Reversed" rawReversed :: Ptr Shape -> Ptr CInt -> Ptr (Ptr ()) -> IO (Ptr Shape)
 
 reversed :: Ptr Shape -> Acquire (Ptr Shape)
-reversed s = mkAcquire (rawReversed s) deleteShape
+reversed s = mkAcquire (wrapException $ rawReversed s) deleteShape
 
 
 -- complement
 --
 
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Complement" complement :: Ptr Shape -> IO ()
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Complement" rawComplement :: Ptr Shape -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
+
+complement :: Ptr Shape -> IO ()
+complement s = wrapException $ rawComplement s
 
 -- complemented
 --
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Complemented" rawComplemented :: Ptr Shape -> IO (Ptr Shape)
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Complemented" rawComplemented :: Ptr Shape -> Ptr CInt -> Ptr (Ptr ()) -> IO (Ptr Shape)
 
 complemented :: Ptr Shape -> Acquire (Ptr Shape)
-complemented s = mkAcquire (rawComplemented s) deleteShape
+complemented s = mkAcquire (wrapException $ rawComplemented s) deleteShape
 
 -- isEqual
 
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_IsEqual" rawIsEqual :: Ptr Shape -> Ptr Shape -> IO CBool
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_IsEqual" rawIsEqual :: Ptr Shape -> Ptr Shape -> Ptr CInt -> Ptr (Ptr ()) -> IO CBool
 
 isEqual :: Ptr Shape -> Ptr Shape -> IO Bool
-isEqual a b = cBoolToBool <$> rawIsEqual a b
+isEqual a b = cBoolToBool <$> wrapException (rawIsEqual a b)
 
 
 -- isSame
 
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_IsSame" rawIsSame :: Ptr Shape -> Ptr Shape -> IO CBool
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_IsSame" rawIsSame :: Ptr Shape -> Ptr Shape -> Ptr CInt -> Ptr (Ptr ()) -> IO CBool
 
 isSame :: Ptr Shape -> Ptr Shape -> IO Bool
-isSame a b = cBoolToBool <$> rawIsSame a b
+isSame a b = cBoolToBool <$> wrapException (rawIsSame a b)
 
 
 -- isPartner
 
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_IsPartner" rawIsPartner :: Ptr Shape -> Ptr Shape -> IO CBool
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_IsPartner" rawIsPartner :: Ptr Shape -> Ptr Shape -> Ptr CInt -> Ptr (Ptr ()) -> IO CBool
 
 isPartner :: Ptr Shape -> Ptr Shape -> IO Bool
-isPartner a b = cBoolToBool <$> rawIsPartner a b
+isPartner a b = cBoolToBool <$> wrapException (rawIsPartner a b)
 
 -- isNotEqual
 
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_IsNotEqual" rawIsNotEqual :: Ptr Shape -> Ptr Shape -> IO CBool
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_IsNotEqual" rawIsNotEqual :: Ptr Shape -> Ptr Shape -> Ptr CInt -> Ptr (Ptr ()) -> IO CBool
 
 isNotEqual :: Ptr Shape -> Ptr Shape -> IO Bool
-isNotEqual a b = cBoolToBool <$> rawIsNotEqual a b
+isNotEqual a b = cBoolToBool <$> wrapException (rawIsNotEqual a b)
 
 -- emptyCopy
 --
 
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_EmptyCopy" emptyCopy :: Ptr Shape -> IO ()
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_EmptyCopy" rawEmptyCopy :: Ptr Shape -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
+
+emptyCopy :: Ptr Shape -> IO ()
+emptyCopy s = wrapException $ rawEmptyCopy s
 
 -- emptyCopied
 --
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_EmptyCopied" rawEmptyCopied :: Ptr Shape -> IO (Ptr Shape)
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_EmptyCopied" rawEmptyCopied :: Ptr Shape -> Ptr CInt -> Ptr (Ptr ()) -> IO (Ptr Shape)
 
 emptyCopied :: Ptr Shape -> Acquire (Ptr Shape)
-emptyCopied s = mkAcquire (rawEmptyCopied s) deleteShape
+emptyCopied s = mkAcquire (wrapException $ rawEmptyCopied s) deleteShape

--- a/opencascade-hs/src/OpenCascade/TopoDS/Shape.hs
+++ b/opencascade-hs/src/OpenCascade/TopoDS/Shape.hs
@@ -35,6 +35,8 @@ module OpenCascade.TopoDS.Shape
 , reversed
 , complement
 , complemented
+, compose
+, composed
 , isEqual
 , isPartner
 , isSame
@@ -306,6 +308,22 @@ foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Complemented" rawC
 
 complemented :: Ptr Shape -> Acquire (Ptr Shape)
 complemented s = mkAcquire (wrapException $ rawComplemented s) deleteShape
+
+-- compose
+--
+
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Compose" rawCompose :: Ptr Shape -> CInt -> Ptr CInt -> Ptr (Ptr ()) -> IO ()
+
+compose :: Ptr Shape -> TopAbs.Orientation -> IO ()
+compose s o = wrapException $ rawCompose s (fromIntegral . fromEnum $ o)
+
+-- composed
+--
+
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_Composed" rawComposed :: Ptr Shape -> CInt -> Ptr CInt -> Ptr (Ptr ()) -> IO (Ptr Shape)
+
+composed :: Ptr Shape -> TopAbs.Orientation -> Acquire (Ptr Shape)
+composed s o = mkAcquire (wrapException $ rawComposed s (fromIntegral . fromEnum $ o)) deleteShape
 
 -- isEqual
 

--- a/opencascade-hs/src/OpenCascade/TopoDS/Types.hs
+++ b/opencascade-hs/src/OpenCascade/TopoDS/Types.hs
@@ -18,6 +18,7 @@ where
 
 
 import OpenCascade.Inheritance
+import OpenCascade.Internal.Exception (wrapException)
 import OpenCascade.TopAbs.ShapeEnum
 import qualified OpenCascade.TopAbs.ShapeEnum as ShapeEnum
 import Foreign.Ptr
@@ -38,10 +39,10 @@ data Builder
 
 -- duplicate definition of shape type from TopoDS.Shape
 -- to simultaniously avoid Orphan Instances + circular dependencies
-foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_ShapeType" rawShapeType :: Ptr Shape -> IO CInt
+foreign import capi unsafe "hs_TopoDS_Shape.h hs_TopoDS_Shape_ShapeType" rawShapeType :: Ptr Shape -> Ptr CInt -> Ptr (Ptr ()) -> IO CInt
 
 shapeType :: Ptr Shape -> IO ShapeEnum
-shapeType s = toEnum . fromIntegral <$> rawShapeType s
+shapeType s = toEnum . fromIntegral <$> wrapException (rawShapeType s)
 
 enumDowncast :: ShapeEnum -> Ptr Shape -> IO (Maybe (Ptr t))
 enumDowncast enum p = do

--- a/opencascade-hs/src/OpenCascade/XCAFDoc/DocumentTool.hs
+++ b/opencascade-hs/src/OpenCascade/XCAFDoc/DocumentTool.hs
@@ -7,10 +7,16 @@ import OpenCascade.XCAFDoc.Types (ShapeTool)
 import OpenCascade.XCAFDoc.Internal.Destructors (deleteShapeToolHandle)
 import OpenCascade.TDF.Types (Label)
 import OpenCascade.Handle (Handle)
+import OpenCascade.Internal.Exception (wrapException)
+import Foreign.C (CInt)
 import Foreign.Ptr (Ptr)
 import Data.Acquire (Acquire, mkAcquire)
 
-foreign import capi unsafe "hs_XCAFDoc_DocumentTool.h hs_XCAFDoc_DocumentTool_shapeTool" rawShapeTool :: Ptr Label -> IO (Ptr (Handle ShapeTool))
+foreign import capi unsafe "hs_XCAFDoc_DocumentTool.h hs_XCAFDoc_DocumentTool_shapeTool" rawShapeTool
+    :: Ptr Label
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr (Handle ShapeTool))
 
 shapeTool :: Ptr Label -> Acquire (Ptr (Handle ShapeTool))
-shapeTool label = mkAcquire  (rawShapeTool label) deleteShapeToolHandle
+shapeTool label = mkAcquire (wrapException $ rawShapeTool label) deleteShapeToolHandle

--- a/opencascade-hs/src/OpenCascade/XCAFDoc/ShapeTool.hs
+++ b/opencascade-hs/src/OpenCascade/XCAFDoc/ShapeTool.hs
@@ -10,11 +10,19 @@ import OpenCascade.Handle (Handle)
 import OpenCascade.TDF.Types (Label)
 import OpenCascade.TDF.Internal.Destructors (deleteLabel)
 import OpenCascade.Internal.Bool (boolToCBool)
+import OpenCascade.Internal.Exception (wrapException)
 import Data.Acquire (Acquire, mkAcquire)
-import Foreign.C (CBool (..))
+import Foreign.C (CBool (..), CInt)
 import Foreign.Ptr (Ptr)
 
-foreign import capi unsafe "hs_XCAFDoc_ShapeTool.h hs_XCAFDoc_ShapeTool_addShape" rawAddShape :: Ptr (Handle ShapeTool) -> Ptr TopoDS.Shape -> CBool -> CBool -> IO (Ptr Label)
+foreign import capi unsafe "hs_XCAFDoc_ShapeTool.h hs_XCAFDoc_ShapeTool_addShape" rawAddShape
+    :: Ptr (Handle ShapeTool)
+    -> Ptr TopoDS.Shape
+    -> CBool
+    -> CBool
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr Label)
 
 addShape :: Ptr (Handle ShapeTool) -> Ptr TopoDS.Shape -> Bool -> Bool -> Acquire (Ptr Label)
-addShape tool shape makeAssembly makePrepare = mkAcquire (rawAddShape tool shape (boolToCBool makeAssembly) (boolToCBool makePrepare)) deleteLabel
+addShape tool shape makeAssembly makePrepare = mkAcquire (wrapException $ rawAddShape tool shape (boolToCBool makeAssembly) (boolToCBool makePrepare)) deleteLabel

--- a/opencascade-hs/src/OpenCascade/XSControl/Reader.hs
+++ b/opencascade-hs/src/OpenCascade/XSControl/Reader.hs
@@ -16,19 +16,32 @@ import Foreign.C.String (CString, withCString)
 import Foreign.C (CInt (..), CBool (..))
 import Foreign.Ptr (Ptr)
 import Data.Acquire (Acquire, mkAcquire)
+import OpenCascade.Internal.Exception (wrapException)
 
-foreign import capi unsafe "hs_XSControl_Reader.h hs_XSControl_Reader_readFile" rawReadFile :: Ptr Reader -> CString -> IO CInt
+foreign import capi unsafe "hs_XSControl_Reader.h hs_XSControl_Reader_readFile" rawReadFile 
+    :: Ptr Reader
+    -> CString
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO CInt
 
 readFile :: Ptr Reader -> String -> IO ReturnStatus
-readFile reader s = toEnum . fromIntegral <$> withCString s (rawReadFile reader)
+readFile reader s = toEnum . fromIntegral <$> withCString s (wrapException . rawReadFile reader)
 
-
-foreign import capi unsafe "hs_XSControl_Reader.h hs_XSControl_Reader_transferRoots" rawTransferRoots :: Ptr Reader  -> IO (CBool)
+foreign import capi unsafe "hs_XSControl_Reader.h hs_XSControl_Reader_transferRoots" rawTransferRoots 
+    :: Ptr Reader 
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (CBool)
 
 transferRoots :: Ptr Reader -> IO Bool
-transferRoots reader = cBoolToBool <$> rawTransferRoots reader
+transferRoots reader = cBoolToBool <$> wrapException (rawTransferRoots reader)
 
-foreign import capi unsafe "hs_XSControl_Reader.h hs_XSControl_Reader_oneShape" rawOneShape :: Ptr Reader  -> IO (Ptr TopoDS.Shape) 
+foreign import capi unsafe "hs_XSControl_Reader.h hs_XSControl_Reader_oneShape" rawOneShape
+    :: Ptr Reader  
+    -> Ptr CInt
+    -> Ptr (Ptr ())
+    -> IO (Ptr TopoDS.Shape) 
 
 oneShape :: Ptr Reader -> Acquire (Ptr TopoDS.Shape)
-oneShape reader  = mkAcquire (rawOneShape reader) deleteShape
+oneShape reader = mkAcquire (wrapException $ rawOneShape reader) deleteShape

--- a/waterfall-cad-examples/package.yaml
+++ b/waterfall-cad-examples/package.yaml
@@ -68,4 +68,5 @@ tests:
     - FontyFruity
     - filepath
     - temporary
+    - resourcet
 

--- a/waterfall-cad-examples/package.yaml
+++ b/waterfall-cad-examples/package.yaml
@@ -60,10 +60,12 @@ tests:
     - waterfall-cad-examples
     - tasty
     - tasty-golden
+    - tasty-hunit
     - rasterific-svg
     - mtl
     - bytestring
     - JuicyPixels
     - FontyFruity
     - filepath
+    - temporary
 

--- a/waterfall-cad-examples/test/ExceptionTests.hs
+++ b/waterfall-cad-examples/test/ExceptionTests.hs
@@ -8,12 +8,15 @@ import qualified Waterfall.Fillet as Fillet
 import qualified Waterfall.Solids as Solids
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit
-import OpenCascade.Internal.Exception (OpenCascadeException (..))
+import OpenCascade.Internal.Exception (OpenCascadeException (..), testThrow)
+import OpenCascade.Std.RuntimeError as RuntimeError 
+import OpenCascade.Inheritance (upcast)
 import Control.Exception (catch, Exception)
 import Control.Monad (when)
 import System.IO.Temp (emptySystemTempFile)
 import qualified Waterfall.IO as IO
 import Waterfall.IO (WaterfallIOException(WaterfallIOException), WaterfallIOExceptionCause (FileError))
+import Data.Acquire (with)
 
 
 checkFailure :: Exception b => IO a -> (b -> Maybe String)  -> IO ()
@@ -51,5 +54,7 @@ exceptionTests = testGroup "Exception Tests"
             $ \case 
                 WaterfallIOException FileError _ -> Nothing
                 e -> Just $ "Expected WaterfallIOException\ngot: " <> show e
-    ,   testCase "Bad Fillet" $ expectFailure (writeTmpStl $ Fillet.roundFillet 2 Solids.centeredCube) (OpenCascadeStandardFailure "BRep_API: command not done" "")
+    , testCase "Bad Fillet" $ expectFailure (writeTmpStl $ Fillet.roundFillet 2 Solids.centeredCube) (OpenCascadeStandardFailure "BRep_API: command not done" "")
+    , testCase "Throw Std Exception" $ with (RuntimeError.new "Some Exception Text") $ \re -> 
+        expectFailure (testThrow (upcast re)) (OpenCascadeStdException "Some Exception Text")
     ]

--- a/waterfall-cad-examples/test/ExceptionTests.hs
+++ b/waterfall-cad-examples/test/ExceptionTests.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE LambdaCase #-}
+module ExceptionTests 
+( exceptionTests
+) where
+
+import qualified Waterfall.Offset as Offset
+import qualified Waterfall.Fillet as Fillet
+import qualified Waterfall.Solids as Solids
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit
+import OpenCascade.Internal.Exception (OpenCascadeException (..))
+import Control.Exception (catch, Exception)
+import Control.Monad (when)
+import System.IO.Temp (emptySystemTempFile)
+import qualified Waterfall.IO as IO
+import Waterfall.IO (WaterfallIOException(WaterfallIOException), WaterfallIOExceptionCause (FileError))
+
+
+checkFailure :: Exception b => IO a -> (b -> Maybe String)  -> IO ()
+checkFailure f check = do
+    success <- catch (f >> pure True) handler
+    when success $ assertFailure "Did not catch expected error"
+    where
+        handler e = 
+            case check e of
+                Nothing -> pure False 
+                Just msg -> 
+                    assertFailure msg
+
+expectFailure :: (Exception b, Eq b) => IO a -> b -> IO ()
+expectFailure f expected = 
+    checkFailure f 
+        (\e -> 
+            if e == expected 
+                then Nothing
+                else Just $ "Caught unexpected error\n" 
+                        <> "expected: " <> show expected
+                        <> "\ngot: " <> show e
+        )
+
+
+writeTmpStl :: Solids.Solid -> IO ()
+writeTmpStl s = do
+    file <- emptySystemTempFile "solid.stl"
+    IO.writeSTL 0.1 file s
+
+exceptionTests :: TestTree
+exceptionTests = testGroup "Exception Tests"
+    [ -- It's a little weird that this fails at IO time, whereas _some_ operations will fail with an OpenCascade exception when the operation is performed
+      testCase "Bad Offset" $ checkFailure (writeTmpStl $ Offset.offset (negate 1) Solids.centeredCube) 
+            $ \case 
+                WaterfallIOException FileError _ -> Nothing
+                e -> Just $ "Expected WaterfallIOException\ngot: " <> show e
+    ,   testCase "Bad Fillet" $ expectFailure (writeTmpStl $ Fillet.roundFillet 2 Solids.centeredCube) (OpenCascadeStandardFailure "BRep_API: command not done" "")
+    ]

--- a/waterfall-cad-examples/test/Main.hs
+++ b/waterfall-cad-examples/test/Main.hs
@@ -3,10 +3,12 @@ module Main
 ) where
 
 import DiagramGoldenTests (diagramGoldenTests)
+import ExceptionTests (exceptionTests)
 import Test.Tasty (defaultMain, testGroup)
 
 
 main :: IO ()
 main = defaultMain $ testGroup "tests"
     [ diagramGoldenTests
+    , exceptionTests
     ]

--- a/waterfall-cad-examples/waterfall-cad-examples.cabal
+++ b/waterfall-cad-examples/waterfall-cad-examples.cabal
@@ -112,6 +112,7 @@ test-suite waterfall-cad-tests
   main-is: Main.hs
   other-modules:
       DiagramGoldenTests
+      ExceptionTests
       Paths_waterfall_cad_examples
   hs-source-dirs:
       test
@@ -134,6 +135,8 @@ test-suite waterfall-cad-tests
     , svg-tree >=0.6 && <1
     , tasty
     , tasty-golden
+    , tasty-hunit
+    , temporary
     , waterfall-cad >=0.6.2.1 && <0.7
     , waterfall-cad-examples
     , waterfall-cad-svg >=0.6.2.1 && <0.7

--- a/waterfall-cad-examples/waterfall-cad-examples.cabal
+++ b/waterfall-cad-examples/waterfall-cad-examples.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.38.1.
+-- This file has been generated from package.yaml by hpack version 0.39.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -132,6 +132,7 @@ test-suite waterfall-cad-tests
     , parser-combinators >=1.2 && <1.4
     , rasterific-svg
     , raw-strings-qq >=1.1 && <2
+    , resourcet
     , svg-tree >=0.6 && <1
     , tasty
     , tasty-golden


### PR DESCRIPTION
This should resolve https://github.com/joe-warren/opencascade-hs/issues/38

Replaces throwing exceptions through the FFI boundary (which is undefined behaviour) with a flag and pointer to a possibly thrown exception. 

Memory management for the thrown exception is done _outside_ of the `Acquire` Monad, and the Haskell exceptions thrown do not contain direct references to any C++ objects. OpenCascade `Standard_Failure`, stl `std::exception` and all other exception types are handled as distinct cases.