### PR TITLE
Add a Nix development shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,77 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1757882181,
+        "narHash": "sha256-+cCxYIh2UNalTz364p+QYmWHs0P+6wDhiWR4jDIKQIU=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "59c44d1909c72441144b93cf0f054be7fe764de5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780365719,
+        "narHash": "sha256-QfWfccTN+70ZQ4m2qlU9PiKfz2Yppq94058iJyARNwc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ffa10e26ae11d676b2db836259889f1f571cb14f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nix-filter": "nix-filter",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,80 @@
+{
+  description = "Flake for OpenCascade-hs and Waterfall CAD";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    nix-filter.url = "github:numtide/nix-filter";
+  };
+  outputs = { self, nixpkgs, flake-utils, nix-filter } :
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        src = nix-filter.lib {
+          root = self;
+          exclude = [
+            (nix-filter.lib.matchExt "nix")
+            "flake.lock"
+          ];
+        };
+
+        inherit (pkgs) lib;
+        inherit (pkgs.haskell.lib) dontCheck doJailbreak overrideCabal markUnbroken;
+
+        ghcVersions = [ "ghc9103" "ghc9124" ];
+        defaultGhcVersion = "ghc9103";
+
+        makeOverlay = ghcVersion:
+          let
+            hsPkgs = pkgs.haskell.packages.${ghcVersion};
+
+            ghcOverrideFile = ./. + "/nix/override-${ghcVersion}.nix";
+            ghcOverrides =
+              if builtins.pathExists ghcOverrideFile then
+                import ghcOverrideFile { inherit pkgs; }
+              else
+                f: p: { };
+
+            overlay = _: prev: {
+              opencascade-hs =
+                prev.callCabal2nix "opencascade-hs"
+                  (src + "/opencascade-hs") {};
+              waterfall-cad =
+                prev.callCabal2nix "waterfall-cad"
+                  (src + "/waterfall-cad") {};
+              waterfall-cad-examples =
+                prev.callCabal2nix "waterfall-cat-examples"
+                  (src + "/waterfall-cad-examples") {};
+              waterfall-cad-svg =
+                prev.callCabal2nix "waterfall-cad-svg"
+                  (src + "/waterfall-cad-svg") {};
+            };
+          in
+            (hsPkgs.extend ghcOverrides).extend overlay;
+
+        overlays = nixpkgs.lib.attrsets.genAttrs ghcVersions makeOverlay;
+
+        makeDevShell = ghcVersion:
+          with overlays.${ghcVersion};
+          shellFor {
+            name = ghcVersion;
+            packages = p: [
+              # project packages
+              p.opencascade-hs
+              p.waterfall-cad
+              p.waterfall-cad-examples
+              p.waterfall-cad-svg
+            ];
+            nativeBuildInputs = [
+              # Haskell dependencies
+              cabal-install
+
+              # other dependencies
+              pkgs.opencascade-occt
+            ];
+          };
+
+        shells = pkgs.lib.attrsets.genAttrs ghcVersions makeDevShell;
+      in {
+        devShells = shells // { default = shells.${defaultGhcVersion}; };
+      });
+}


### PR DESCRIPTION
The PR adds a `flake.nix` to easily build the development version using a Nix development shell. 

To be noted: the PR only adds some development shells, but does not create a Nix package as in #12. The stackage mirror in `nixpkgs` can be used of this purpose instead.

The development shell also supports easy switching between different GHC versions via providing corresponding shells for each requested version.