### PR TITLE
Add optics based on the `Transformable` and `Transformable2D` typeclasses

### DIFF
--- a/waterfall-cad/CHANGELOG.md
+++ b/waterfall-cad/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to the
 ## Unreleased
 
 - Fixed an issue in `Waterfall.Transforms` where negative coefficients to `scale` would produce a broken `Solid`
+- Added optics derived from the `Transformable` typeclass, `_translated`, `_scaled`, `_uScaled`, `_rotated`, `_mirrored` and their 2D equivalents.
 
 ## 0.6.2.1
 

--- a/waterfall-cad/src/Waterfall/Transforms.hs
+++ b/waterfall-cad/src/Waterfall/Transforms.hs
@@ -1,20 +1,28 @@
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ImpredicativeTypes #-}
 module Waterfall.Transforms
-( Transformable
+( -- * Transformations
+  Transformable
 , matTransform
 , scale
 , uScale
 , rotate
 , translate
 , mirror
+  -- * Optics
+, _translated
+, _scaled
+, _uScaled
+, _rotated
+, _mirrored
 ) where
 import Waterfall.Internal.Solid (Solid (..), acquireSolid, solidFromAcquire)
 import Waterfall.Internal.Finalizers (toAcquire, unsafeFromAcquire) 
 import Waterfall.Internal.Path.Common (RawPath(..))
 import Linear.V3 (V3 (..))
 import Linear.V4 (V4 (..))
-import Linear (M34, (*^), normalize, dot, (!*), unit, _w, _xyz, _x, _y, _z)
+import Linear (M34, (*^), normalize, dot, (!*), unit, _w, _xyz, _x, _y, _z, nearZero)
 import qualified Linear.Quaternion as Quaternion
 import qualified OpenCascade.GP.Trsf as GP.Trsf
 import qualified OpenCascade.GP as GP
@@ -32,7 +40,7 @@ import Foreign.Ptr
 import Waterfall.Internal.Path (Path(..))
 import OpenCascade.Inheritance (upcast, unsafeDowncast)
 import Data.Function ((&))
-import Control.Lens ((.~))
+import Control.Lens ((.~), Iso', iso)
 
 -- | Typeclass for objects that can be manipulated in 3D space
 class Transformable a where
@@ -244,3 +252,34 @@ instance Transformable (V3 Double) where
         let nm = normalize mirrorVec
         in toMirror - (2 * (nm `dot` toMirror) *^ nm)
 
+-- | Every translation is an isomorphism
+_translated :: Transformable t => V3 Double -> Iso' t t
+_translated v = iso (translate v) (translate (negate v))
+
+-- | A scale by @v@ as an isomorphism
+--
+-- Returns 'Nothing' when any component of @v@ is (near) zero,
+-- as a scale that collapses an axis has no inverse.
+_scaled :: Transformable t => V3 Double -> Maybe (Iso' t t)
+_scaled v =
+    if any nearZero v
+        then Nothing
+        else Just $ iso (scale v) (scale (1/v))
+
+-- | A scale by @s@ as an isomorphism
+--
+-- Returns 'Nothing' when @s@ is (near) zero,
+--  as a scale that collapses everything to the origin has no inverse.
+_uScaled :: Transformable t => Double -> Maybe (Iso' t t)
+_uScaled s = 
+    if nearZero s
+        then Nothing 
+        else Just $ iso (uScale s) (uScale (1/s))
+
+-- | Every rotation is an isomorphism
+_rotated :: Transformable t => V3 Double -> Double -> Iso' t t
+_rotated axis angle = iso (rotate axis angle) (rotate axis (negate angle))
+
+-- | Every mirror is an isomorphism
+_mirrored :: Transformable t => V3 Double -> Iso' t t
+_mirrored v = let f = mirror v in iso f f 

--- a/waterfall-cad/src/Waterfall/TwoD/Transforms.hs
+++ b/waterfall-cad/src/Waterfall/TwoD/Transforms.hs
@@ -1,18 +1,26 @@
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ImpredicativeTypes #-}
 module Waterfall.TwoD.Transforms
-( Transformable2D
+( -- * Transformations
+ Transformable2D
 , matTransform2D
 , rotate2D
 , scale2D
 , uScale2D
 , translate2D
 , mirror2D
+-- * Optics
+, _translated2D
+, _scaled2D
+, _uScaled2D
+, _rotated2D
+, _mirrored2D
 ) where
 
 import Waterfall.TwoD.Internal.Path2D (Path2D (..))
 import Waterfall.Internal.Finalizers (toAcquire, unsafeFromAcquire)
-import Linear ((*^), normalize, dot, V3 (..), V2 (..), (!*), _xy, _z, unit, M23)
+import Linear ((*^), normalize, dot, V3 (..), V2 (..), (!*), _xy, _z, unit, M23, nearZero)
 import qualified OpenCascade.GP.Trsf as GP.Trsf
 import qualified OpenCascade.GP as GP
 import qualified OpenCascade.GP.GTrsf as GP.GTrsf
@@ -28,7 +36,7 @@ import Data.Acquire
 import Foreign.Ptr
 import Waterfall.TwoD.Internal.Shape (Shape(..))
 import Data.Function ((&))
-import Control.Lens ((.~), (%~))
+import Control.Lens ((.~), (%~), Iso', iso)
 import Control.Monad (forM)
 import Waterfall.Internal.Path.Common (RawPath(..))
 import Waterfall.Internal.Diagram (RawDiagram (..))
@@ -238,3 +246,33 @@ instance Transformable2D (V2 Double) where
     mirror2D mirrorVec toMirror = 
         let nm = normalize mirrorVec
         in toMirror - (2 * (nm `dot` toMirror) *^ nm)
+
+-- | Every translation is an isomorphism
+_translated2D :: Transformable2D t => V2 Double -> Iso' t t
+_translated2D v = iso (translate2D v) (translate2D (negate v))
+
+-- | A scale by @v@ as an isomorphism
+--
+-- Returns 'Nothing' when any component of @v@ is (near) zero,
+-- as a scale that collapses an axis has no inverse.
+_scaled2D :: Transformable2D t => V2 Double -> Maybe (Iso' t t)
+_scaled2D v = if any nearZero v
+    then Nothing
+    else Just $ iso (scale2D v) (scale2D (1/v))
+
+-- | A scale by @s@ as an isomorphism
+--
+-- Returns 'Nothing' when @s@ is (near) zero,
+--  as a scale that collapses everything to the origin has no inverse.
+_uScaled2D :: Transformable2D t => Double -> Maybe (Iso' t t)
+_uScaled2D s = if nearZero s
+    then Nothing
+    else Just $ iso (uScale2D s) (uScale2D (1/s))
+
+-- | Every rotation is an isomorphism
+_rotated2D :: Transformable2D t => Double -> Iso' t t
+_rotated2D angle = iso (rotate2D angle) (rotate2D (negate angle))
+
+-- | Every mirror is an isomorphism
+_mirrored2D :: Transformable2D t => V2 Double -> Iso' t t
+_mirrored2D v = let f = mirror2D v in iso f f


### PR DESCRIPTION
This represents the parts of https://github.com/joe-warren/opencascade-hs/pull/19 which I think are worth keeping